### PR TITLE
chore(components): copy using the project.json definition

### DIFF
--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -33,7 +33,23 @@
         "tsConfig": "libs/components/tsconfig.lib.json",
         "project": "libs/components/package.json",
         "rollupConfig": "libs/components/rollup.config.prod.ts",
-        "assets": [],
+        "assets": [
+          {
+            "input": "./libs/components/**",
+            "glob": "*.md",
+            "output": "."
+          },
+          {
+            "input": "./dist/libs/styles/themes/**",
+            "glob": "*.css",
+            "output": "./styles/themes"
+          },
+          {
+            "input": "./dist/libs/styles/fonts/**",
+            "glob": "*.css",
+            "output": "./styles/fonts"
+          }
+        ],
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "updateBuildableProjectDepsInPackageJson": true
       }
@@ -48,7 +64,6 @@
         "project": "libs/components/package.json",
         "rollupConfig": "libs/components/rollup.config.prod.ts",
         "watch": true,
-        "assets": [],
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "updateBuildableProjectDepsInPackageJson": true
       }

--- a/libs/components/rollup.config.base.ts
+++ b/libs/components/rollup.config.base.ts
@@ -1,13 +1,23 @@
+const path = require('path');
 const typescript = require('@rollup/plugin-typescript');
 const nodeResolve = require('@rollup/plugin-node-resolve').default;
 const litCss = require('rollup-plugin-lit-css').default;
+const copy = require('rollup-plugin-copy');
 const {renderSync} = require('sass');
+
+const {targets: {build: {options: {assets}}}} = require('./project.json');
+
+const targets = assets.map(asset => ({
+	src: path.join(asset.input, asset.glob),
+	dest: path.join('./dist/libs/components/', asset.output)
+}));
 
 const BASE_CONFIG = {
 	watch: {
 		clearScreen: false,
 	},
 	plugins: [
+		copy({targets}),
 		typescript({
 			noEmitOnError: true,
 			tsconfig: './libs/components/tsconfig.lib.json',
@@ -15,9 +25,14 @@ const BASE_CONFIG = {
 		litCss({
 			specifier: '@microsoft/fast-element',
 			include: ['/**/*.scss'],
-			transform: (data, { filePath }) => {
+			transform: (data, {filePath}) => {
 				console.log(filePath);
-				return renderSync({ data, file: filePath }).css.toString();
+				return renderSync({
+					data,
+					file: filePath
+				})
+					.css
+					.toString();
 			},
 		}),
 		nodeResolve(),

--- a/libs/components/rollup.config.prod.ts
+++ b/libs/components/rollup.config.prod.ts
@@ -28,6 +28,8 @@ const input = components.reduce((inputObject, componentName) => {
 }, {});
 
 module.exports = function setVividRollupConfig(config) {
+
+	const plugins = [...rollupBaseConfig.plugins];
 	return {
 		input,
 		output: {
@@ -36,6 +38,6 @@ module.exports = function setVividRollupConfig(config) {
 			format: 'esm',
 			chunkFileNames: 'components/[name]/chunks/index.js',
 		},
-		...rollupBaseConfig,
+		plugins
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "nx-stylelint": "^13.1.0",
         "playwright": "1.16.3",
         "prettier": "^2.3.1",
+        "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-delete": "^2.0.0",
         "rollup-plugin-lit-css": "^3.2.1",
         "sass": "^1.47.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "nx-stylelint": "^13.1.0",
     "playwright": "1.16.3",
     "prettier": "^2.3.1",
+    "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-lit-css": "^3.2.1",
     "sass": "^1.47.0",


### PR DESCRIPTION
Now when building it also copies the readme and the styles (into the `styles` folder inside `dist/components`).