### PR TITLE
refactor(components): rename size to density

### DIFF
--- a/change/@vonage-vivid-c321371a-c7b0-41ab-b9e3-4bddc6b11156.json
+++ b/change/@vonage-vivid-c321371a-c7b0-41ab-b9e3-4bddc6b11156.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "rename size (for block size members) to density due to its being a reserved name in input element",
+  "packageName": "@vonage/vivid",
+  "email": "yinon@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/libs/components/src/lib/badge/README.md
+++ b/libs/components/src/lib/badge/README.md
@@ -21,18 +21,18 @@ Add a `text` attribute to add text to the badge.
 <vwc-badge text='A default badge'></vwc-badge>
 ```
 
-## Size
+## Density
 
-Use the `size` attribute to change the badge's size.
+Use the `density` attribute to set the badge's to one of the predefined block size extent.
 
 - Type: `'condensed'` | `'normal'` | `'extended'`
 - Default: `'normal'`
 
 
 ```html preview
-<vwc-badge text='condensed' size='condensed'></vwc-badge>
-<vwc-badge text='normal' size='normal'></vwc-badge>
-<vwc-badge text='extended' size='extended'></vwc-badge>
+<vwc-badge text='condensed' density='condensed'></vwc-badge>
+<vwc-badge text='normal' density='normal'></vwc-badge>
+<vwc-badge text='extended' density='extended'></vwc-badge>
 ```
 
 ## Shape

--- a/libs/components/src/lib/badge/badge.scss
+++ b/libs/components/src/lib/badge/badge.scss
@@ -31,17 +31,17 @@
 
 /* Size */
 
-.control:not(.size-condensed):not(.size-extended) {
+.control:not(.density-condensed):not(.density-extended) {
 	block-size: 24px;
 	padding-inline: 10px;
 }
 
-.control.size-condensed {
+.control.density-condensed {
 	block-size: 20px;
 	padding-inline: 8px;
 }
 
-.control.size-extended {
+.control.density-extended {
 	block-size: 28px;
 	padding-inline: 12px;
 }

--- a/libs/components/src/lib/badge/badge.spec.ts
+++ b/libs/components/src/lib/badge/badge.spec.ts
@@ -22,7 +22,7 @@ describe('vwc-badge', () => {
 			expect(element.connotation).toBeUndefined();
 			expect(element.shape).toBeUndefined();
 			expect(element.appearance).toBeUndefined();
-			expect(element.size).toBeUndefined();
+			expect(element.density).toBeUndefined();
 		});
 	});
 
@@ -100,13 +100,13 @@ describe('vwc-badge', () => {
 		});
 	});
 
-	describe('size', () => {
-		it('sets correct internal size style', async () => {
-			const size = 'condensed';
-			(element as any).size = size;
+	describe('density', () => {
+		it('sets correct internal density style', async () => {
+			const density = 'condensed';
+			(element as any).density = density;
 			await elementUpdated(element);
 
-			const control = element.shadowRoot?.querySelector(`.control.size-${size}`);
+			const control = element.shadowRoot?.querySelector(`.control.density-${density}`);
 			expect(control)
 				.toBeInstanceOf(Element);
 		});

--- a/libs/components/src/lib/badge/badge.template.ts
+++ b/libs/components/src/lib/badge/badge.template.ts
@@ -6,13 +6,13 @@ import { affixIconTemplateFactory } from '../../shared/patterns/affix';
 import type { Badge } from './badge';
 
 const getClasses = ({
-	connotation, appearance, shape, size, iconTrailing
+	connotation, appearance, shape, density, iconTrailing
 }: Badge) => classNames(
 	'control',
 	[`connotation-${connotation}`, Boolean(connotation)],
 	[`appearance-${appearance}`, Boolean(appearance)],
 	[`shape-${shape}`, Boolean(shape)],
-	[`size-${size}`, Boolean(size)],
+	[`density-${density}`, Boolean(density)],
 	['icon-trailing', iconTrailing],
 );
 

--- a/libs/components/src/lib/badge/badge.ts
+++ b/libs/components/src/lib/badge/badge.ts
@@ -81,7 +81,7 @@ export class Badge extends FoundationElement {
 	 * @remarks
 	 * HTML Attribute: size
 	 */
-	@attr size?: BadgeDensity;
+	@attr density?: BadgeDensity;
 
 	/**
 	 * Indicates the badge's text.

--- a/libs/components/src/lib/badge/badge.ts
+++ b/libs/components/src/lib/badge/badge.ts
@@ -3,7 +3,7 @@ import { attr } from '@microsoft/fast-element';
 import { AffixIconWithTrailing } from '../../shared/patterns/affix';
 
 import type {
-	Appearance, BlockSize, Connotation, Shape,
+	Appearance, Connotation, Density, Shape,
 } from '../enums.js';
 
 /**
@@ -35,11 +35,11 @@ Appearance.Filled | Appearance.Duotone | Appearance.Subtle>;
 type BadgeShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
- * Types of badge size.
+ * Types of badge density.
  *
  * @public
  */
-type BadgeSize = Extract<BlockSize, BlockSize.Condensed | BlockSize.Normal | BlockSize.Extended>;
+type BadgeDensity = Extract<Density, Density.Condensed | Density.Normal | Density.Extended>;
 
 /**
  * Base class for badge
@@ -81,7 +81,7 @@ export class Badge extends FoundationElement {
 	 * @remarks
 	 * HTML Attribute: size
 	 */
-	@attr size?: BadgeSize;
+	@attr size?: BadgeDensity;
 
 	/**
 	 * Indicates the badge's text.

--- a/libs/components/src/lib/banner/banner.template.ts
+++ b/libs/components/src/lib/banner/banner.template.ts
@@ -21,7 +21,7 @@ const getClasses = (_: Banner) => classNames(
 function renderDismissButton() {
 	return html<Banner>`
 	  <vwc-button
-			  size="condensed"
+			  density="condensed"
 			  class="dismiss-button"
 			  icon="close-line"
 			  @click="${x => x.remove()}">

--- a/libs/components/src/lib/button/README.md
+++ b/libs/components/src/lib/button/README.md
@@ -19,17 +19,17 @@ Add a `label` attribute to add text to the button.
 <vwc-button appearance='filled' label='A default button'></vwc-button>
 ```
 
-## Size
+## Density
 
-Use the `size` attribute to set the button's to one of the predefined block size extent.
+Use the `density` attribute to set the button's to one of the predefined block size extent.
 
 - Type: `'condensed'` | `'normal'` | `'extended'`
 - Default: `'normal'`
 
 ```html preview
-<vwc-button appearance='filled' label='condensed' size='condensed'></vwc-button>
-<vwc-button appearance='filled' label='normal' size='normal'></vwc-button>
-<vwc-button appearance='filled' label='extended' size='extended'></vwc-button>
+<vwc-button appearance='filled' label='condensed' density='condensed'></vwc-button>
+<vwc-button appearance='filled' label='normal' density='normal'></vwc-button>
+<vwc-button appearance='filled' label='extended' density='extended'></vwc-button>
 ```
 
 ## Shape
@@ -86,7 +86,7 @@ Set the `stacked` attribute to change the button's layout to stacked.
 Caveats:
 
 - This is only applicable to the `'rounded'` shape.
-- This Will override any [size](#size) style to the predefined stacked size.
+- This will override any applied [density](#density) style to match a predefined stacked block size.
 
 ```html preview
 <vwc-button stacked appearance='filled' label='Stacked'></vwc-button>
@@ -132,6 +132,7 @@ It accepts a subset of predefined values.
 
 ## States
 ### Disabled
+
 ```html preview
 <vwc-button disabled appearance='ghost' label='ghost'></vwc-button>
 <vwc-button disabled appearance='filled' label='filled'></vwc-button>

--- a/libs/components/src/lib/button/button.scss
+++ b/libs/components/src/lib/button/button.scss
@@ -59,23 +59,23 @@
 	/* Size */
 
 	&:not(.stacked) {
-		&.size-condensed {
-			@include mixins.get-size-properties(32px, caption-bold, 8px, 12px, 16px);
+		&.density-condensed {
+			@include mixins.get-density-properties(32px, caption-bold, 8px, 12px, 16px);
 		}
 
-		&.size-extended {
-			@include mixins.get-size-properties(48px, body-1-bold, 10px, 20px, 24px);
+		&.density-extended {
+			@include mixins.get-density-properties(48px, body-1-bold, 10px, 20px, 24px);
 		}
 
-		&:not(.size-condensed, .size-extended) {
-			@include mixins.get-size-properties(40px, button, 8px, 16px, 20px);
+		&:not(.density-condensed, .density-extended) {
+			@include mixins.get-density-properties(40px, button, 8px, 16px, 20px);
 		}
 	}
 
 	&.stacked {
 		flex-direction: column;
 		justify-content: center;
-		@include mixins.get-size-properties(68px, body-2-bold, 10px, 16px, 20px);
+		@include mixins.get-density-properties(68px, body-2-bold, 10px, 16px, 20px);
 	}
 }
 

--- a/libs/components/src/lib/button/button.spec.ts
+++ b/libs/components/src/lib/button/button.spec.ts
@@ -22,7 +22,7 @@ describe('vwc-button', () => {
 			expect(element.connotation).toBeUndefined();
 			expect(element.shape).toBeUndefined();
 			expect(element.appearance).toBeUndefined();
-			expect(element.size).toBeUndefined();
+			expect(element.density).toBeUndefined();
 		});
 	});
 
@@ -92,13 +92,13 @@ describe('vwc-button', () => {
 		});
 	});
 
-	describe('size', () => {
-		it('sets correct internal size style', async () => {
-			const size = 'condensed';
-			(element as any).size = size;
+	describe('density', () => {
+		it('sets correct internal density style', async () => {
+			const density = 'condensed';
+			(element as any).density = density;
 			await elementUpdated(element);
 
-			const control = element.shadowRoot?.querySelector(`.control.size-${size}`);
+			const control = element.shadowRoot?.querySelector(`.control.density-${density}`);
 			expect(control).toBeInstanceOf(Element);
 		});
 	});

--- a/libs/components/src/lib/button/button.template.ts
+++ b/libs/components/src/lib/button/button.template.ts
@@ -14,13 +14,13 @@ const getAppearanceClassName = (appearance: ButtonAppearance, disabled: boolean)
 };
 
 const getClasses = ({
-	connotation, appearance, shape, size, iconTrailing, icon, label, disabled, stacked
+	connotation, appearance, shape, density, iconTrailing, icon, label, disabled, stacked
 }: Button) => classNames(
 	'control',
 	[`connotation-${connotation}`, Boolean(connotation)],
 	[getAppearanceClassName(appearance as ButtonAppearance, disabled), Boolean(appearance)],
 	[`shape-${shape}`, Boolean(shape)],
-	[`size-${size}`, Boolean(size)],
+	[`density-${density}`, Boolean(density)],
 	['icon-only', !label && !!icon],
 	['icon-trailing', iconTrailing],
 	['stacked', Boolean(stacked)],

--- a/libs/components/src/lib/button/button.ts
+++ b/libs/components/src/lib/button/button.ts
@@ -79,7 +79,7 @@ export class Button extends FoundationButton {
 	 * @remarks
 	 * HTML Attribute: size
 	 */
-	@attr size?: ButtonDensity;
+	@attr density?: ButtonDensity;
 
 	/**
 	 * Indicates the icon is stacked.

--- a/libs/components/src/lib/button/button.ts
+++ b/libs/components/src/lib/button/button.ts
@@ -2,7 +2,7 @@ import { applyMixins, Button as FoundationButton } from '@microsoft/fast-foundat
 import { attr } from '@microsoft/fast-element';
 
 import type {
-	Appearance, BlockSize, Connotation, Shape,
+	Appearance, Connotation, Density, Shape,
 } from '../enums.js';
 import { AffixIconWithTrailing } from '../../shared/patterns/affix';
 
@@ -37,7 +37,7 @@ type ButtonShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
  *
  * @public
  */
-type ButtonSize = Extract<BlockSize, BlockSize.Condensed | BlockSize.Normal | BlockSize.Extended>;
+type ButtonDensity = Extract<Density, Density.Condensed | Density.Normal | Density.Extended>;
 
 /**
  * Base class for button
@@ -79,7 +79,7 @@ export class Button extends FoundationButton {
 	 * @remarks
 	 * HTML Attribute: size
 	 */
-	@attr size?: ButtonSize;
+	@attr size?: ButtonDensity;
 
 	/**
 	 * Indicates the icon is stacked.

--- a/libs/components/src/lib/button/partials/_mixins.scss
+++ b/libs/components/src/lib/button/partials/_mixins.scss
@@ -2,7 +2,7 @@
 @use '../../../../../shared/src/lib/sass/mixins/typography' as typography;
 
 
-@mixin get-size-properties($block-size, $font-face, $icon-gap, $padding-inline, $icon-size) {
+@mixin get-density-properties($block-size, $font-face, $icon-gap, $padding-inline, $icon-size) {
 	#{variables.$block-size}: $block-size;
 	@include typography.typography-cat-shorthand($font-face);
 

--- a/libs/components/src/lib/enums.ts
+++ b/libs/components/src/lib/enums.ts
@@ -31,7 +31,7 @@ export enum Appearance {
 	Ghost = 'ghost',
 }
 
-export enum BlockSize {
+export enum Density {
 	Condensed = 'condensed',
 	Normal = 'normal',
 	Extended = 'extended',

--- a/libs/components/src/lib/popup/popup.template.ts
+++ b/libs/components/src/lib/popup/popup.template.ts
@@ -31,7 +31,7 @@ export const popupTemplate: (
 				<div class="popup-content">
 					<slot></slot>
 					${when(x => x.dismissible,
-		html<Popup>`<vwc-button size="condensed" @click="${x => (x.open = false)}"
+		html<Popup>`<vwc-button density="condensed" @click="${x => (x.open = false)}"
 						class="dismissible" icon="close-small-solid" shape="pill"></vwc-button>`)}
 				</div>
 				${when(x => x.arrow,


### PR DESCRIPTION
rename size (for block size members) to density due to its being a reserved name in input element