### PR TITLE
fix(docs): remove permanent from dark-mode-toggle

### DIFF
--- a/apps/docs/_layouts/base.njk
+++ b/apps/docs/_layouts/base.njk
@@ -72,7 +72,7 @@
 
         <vwc-text font-face="body-1-bold" tight>VIVID Web Components</vwc-text>
       </a>
-      			<dark-mode-toggle	slot="action-items" permanent appearance="toggle"></dark-mode-toggle>
+      			<dark-mode-toggle	slot="action-items" appearance="toggle"></dark-mode-toggle>
 
             <vwc-button slot="action-items" aria-label="View on GitHub" icon="github-mono" icon-trailing href="https://github.com/vonage/vivid-3"></vwc-button>
 


### PR DESCRIPTION
bug description:

1. click on dark-mode-toggle button to change theme 
2. click on a different page on the side-navigation
3. the theme resets back to the prev theme