### PR TITLE
build(components): generate custom.elements.json

### DIFF
--- a/libs/components/.gitignore
+++ b/libs/components/.gitignore
@@ -1,0 +1,1 @@
+custom-elements.json

--- a/libs/components/custom-elements-manifest.config.mjs
+++ b/libs/components/custom-elements-manifest.config.mjs
@@ -1,0 +1,20 @@
+export default {
+	/** Globs to analyze */
+	globs: ['src/lib/**/*.ts'],
+	/** Globs to exclude */
+	exclude: [
+		'src/lib/*.ts',
+		'src/lib/**/*.md',
+		'src/lib/**/ui.test.ts',
+		'src/lib/**/*.spec.ts',
+		'src/lib/**/*.template.ts',
+		'src/lib/**/index.ts',
+	],
+	packagejson: true,
+	/** Directory to output CEM to */
+	// outdir: '../../dist/libs/components',
+	/** Run in dev mode, provides extra logging */
+	dev: false,
+	/** Enable special handling for fast */
+	fast: true,
+};

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -54,5 +54,6 @@
     "./text-field": "./text-field",
     "./text-area": "./text-area",
     "./tooltip": "./tooltip"
-  }
+  },
+  "customElements": "custom-elements.json"
 }


### PR DESCRIPTION
custom elements manifest is a schema published as a JSON and allows tooling and IDEs to give rich information about the custom elements in a given project.

for more - https://github.com/webcomponents/custom-elements-manifest

required steps -

- [ ] run `cem analyze --config "custom-elements-manifest.config.mjs"` pre-packaging step
- [ ] generate readme / .md from base classes. code snippets could be included in JSDocs comments and rendered by plugins (as [plugins: [jsdocLinkFix()]](https://github.com/yinonov/fast/blob/e0df1e06ae6674b0bf9adbd2a346b720f83c6b6c/packages/web-components/fast-foundation/custom-elements-manifest.config.mjs#L23-L24)) (can be extracted to a following scope)

assistive tools
https://github.com/open-wc/custom-elements-manifest
