### PR TITLE
fix(components): option align property with naming convention

### DIFF
--- a/change/@vonage-vivid-dbf94fe7-0778-4f8c-9311-8a04f662a5f2.json
+++ b/change/@vonage-vivid-dbf94fe7-0778-4f8c-9311-8a04f662a5f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "option class - align property with naming convetion",
+  "packageName": "@vonage/vivid",
+  "email": "yinon@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/libs/components/src/lib/listbox-option/listbox-option.spec.ts
+++ b/libs/components/src/lib/listbox-option/listbox-option.spec.ts
@@ -18,7 +18,7 @@ describe('vwc-option', () => {
 	describe('basic', () => {
 		it('should be initialized as a vwc-option', async () => {
 			expect(element).toBeInstanceOf(ListboxOption);
-			expect(element.text).toBeUndefined();
+			expect(element.text).toEqual('');
 			expect(element.icon).toBeUndefined();
 			expect(element.selected).toBeFalsy();
 			expect(element.checked).toBeUndefined();

--- a/libs/components/src/lib/listbox-option/listbox-option.spec.ts
+++ b/libs/components/src/lib/listbox-option/listbox-option.spec.ts
@@ -18,7 +18,7 @@ describe('vwc-option', () => {
 	describe('basic', () => {
 		it('should be initialized as a vwc-option', async () => {
 			expect(element).toBeInstanceOf(ListboxOption);
-			expect(element.optionText).toBeUndefined();
+			expect(element.text).toBeUndefined();
 			expect(element.icon).toBeUndefined();
 			expect(element.selected).toBeFalsy();
 			expect(element.checked).toBeUndefined();
@@ -43,7 +43,7 @@ describe('vwc-option', () => {
 		it('should set text property value as text content', async () => {
 			const text = 'lorem';
 
-			element.optionText = text;
+			element.text = text;
 			await elementUpdated(element);
 
 			const base = element.shadowRoot?.querySelector('.base');

--- a/libs/components/src/lib/listbox-option/listbox-option.template.ts
+++ b/libs/components/src/lib/listbox-option/listbox-option.template.ts
@@ -37,7 +37,7 @@ export const ListboxOptionTemplate: (
 		<div class="${getClasses}">
 			${() => focusTemplate}
 			${x => affixIconTemplate(x.icon)}
-			${when(x => x.optionText, html`<div class="text">${x => x.optionText}</div>`)}
+			${when(x => x.text, html`<div class="text">${x => x.text}</div>`)}
 		</div>
 	</template>
 	`;

--- a/libs/components/src/lib/listbox-option/listbox-option.ts
+++ b/libs/components/src/lib/listbox-option/listbox-option.ts
@@ -13,11 +13,21 @@ export class ListboxOption extends FoundationListboxOption {
 	 *
 	 * @public
 	 *
-	 * HTML Attribute: optionText
+	 * HTML Attribute: text
 	 */
 	@attr({
 		attribute: 'text',
-	}) optionText?: string; // TODO: This should be named text
+	}) _text?: string;
+
+	// #region overrides base class accessor
+	override set text(value) {
+		this._text = value;
+	}
+
+	override get text() {
+		return this._text ?? '';
+	}
+	// #endregion overrides
 }
 
 export interface ListboxOption extends AffixIconWithTrailing { }


### PR DESCRIPTION
rename optionText property to text to align with components naming
convention