### PR TITLE
[DO NOT MERGE] feeding ESM to Jest

### DIFF
--- a/libs/components/jest.config.cjs
+++ b/libs/components/jest.config.cjs
@@ -2,18 +2,11 @@
 
 module.exports = {
   displayName: 'components',
-//   preset: '../../jest.preset.js',
   preset: 'ts-jest/presets/default-esm',
-	// resolver: '@nrwl/jest/plugins/resolver',
   testEnvironment: 'jsdom',
   moduleNameMapper: {
 	  "@vivid-nx/shared": "<rootDir>/../../libs/shared/src/index.ts",
-    // "dialog-polyfill": "<rootDir>/../../node_modules/dialog-polyfill/dist/dialog-polyfill.js"
   },
-  // roots: ['<rootDir>'],
-  // modulePaths: ['<rootDir>', '/dist'],
-  // moduleDirectories: ['node_modules', 'dist'],
-
   globals: {
     'ts-jest': {
   		useESM: true,
@@ -22,19 +15,14 @@ module.exports = {
   },
   transform: {
     ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
-  //   '^.+\\.[tj]s?$': 'ts-jest',
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@microsoft|exenv-es6)/)"
+    "/node_modules/(?!(@microsoft|exenv-es6)/)",
+    "dialog-polyfill.css"
   ],
-  // transformIgnorePatterns: [
-  //   "/node_modules/dialog-polyfill/"
-  // ],
-  // moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-//   coverageDirectory: '../../coverage/libs/components',
   testMatch: [
     "**/__tests__/**/*.[jt]s?(x)",
-    "**/?(*.)+(icon.spec).[jt]s?(x)",
+    "**/?(*.)+(spec).[jt]s?(x)",
     "!**/?(*.)+(dialog.spec).[jt]s?(x)",
     "!**/?(*.)+(config.spec).[jt]s?(x)"
   ],

--- a/libs/components/jest.config.cjs
+++ b/libs/components/jest.config.cjs
@@ -1,20 +1,42 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+
 module.exports = {
   displayName: 'components',
-  preset: '../../jest.preset.js',
+//   preset: '../../jest.preset.js',
+  preset: 'ts-jest/presets/default-esm',
+	// resolver: '@nrwl/jest/plugins/resolver',
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+	  "@vivid-nx/shared": "<rootDir>/../../libs/shared/src/index.ts",
+    // "dialog-polyfill": "<rootDir>/../../node_modules/dialog-polyfill/dist/dialog-polyfill.js"
+  },
+  // roots: ['<rootDir>'],
+  // modulePaths: ['<rootDir>', '/dist'],
+  // moduleDirectories: ['node_modules', 'dist'],
+
   globals: {
     'ts-jest': {
+  		useESM: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
     },
   },
   transform: {
-    '^.+\\.[tj]s?$': 'ts-jest',
+    ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
+  //   '^.+\\.[tj]s?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     "/node_modules/(?!(@microsoft|exenv-es6)/)"
   ],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/libs/components',
-  testMatch: [ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec).[jt]s?(x)", "!**/?(*.)+(config.spec).[jt]s?(x)" ],
+  // transformIgnorePatterns: [
+  //   "/node_modules/dialog-polyfill/"
+  // ],
+  // moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+//   coverageDirectory: '../../coverage/libs/components',
+  testMatch: [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(icon.spec).[jt]s?(x)",
+    "!**/?(*.)+(dialog.spec).[jt]s?(x)",
+    "!**/?(*.)+(config.spec).[jt]s?(x)"
+  ],
   setupFilesAfterEnv: ["<rootDir>/setupJestTests.js"]
 };

--- a/libs/components/setupJestTests.js
+++ b/libs/components/setupJestTests.js
@@ -1,10 +1,15 @@
-import * as jestFetchMock from 'jest-fetch-mock';
+// import * as jestFetchMock from 'jest-fetch-mock';
 
-jestFetchMock.enableFetchMocks();
+// jestFetchMock.enableFetchMocks();
+
+import { jest } from '@jest/globals';
+import fetchMocks from 'jest-fetch-mock';
+
+fetchMocks.enableMocks();
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,
-	value: jest.fn().mockImplementation((query: any) => ({
+	value: jest.fn().mockImplementation((query) => ({
 		matches: false,
 		media: query,
 		onchange: null,

--- a/libs/components/src/lib/accordion-item/accordion-item.spec.ts
+++ b/libs/components/src/lib/accordion-item/accordion-item.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getBaseElement } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { AccordionItem } from './accordion-item';
 import '.';
 

--- a/libs/components/src/lib/accordion/accordion.spec.ts
+++ b/libs/components/src/lib/accordion/accordion.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import type { AccordionItem } from '../accordion-item/accordion-item';
 import { Accordion } from './accordion';
 import '.';

--- a/libs/components/src/lib/action-group/action-group.spec.ts
+++ b/libs/components/src/lib/action-group/action-group.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { ActionGroup } from './action-group';
 import '.';
 

--- a/libs/components/src/lib/avatar/avatar.spec.ts
+++ b/libs/components/src/lib/avatar/avatar.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, getBaseElement} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Connotation} from '../enums';
 import { Avatar } from './avatar';
 import '.';

--- a/libs/components/src/lib/badge/badge.spec.ts
+++ b/libs/components/src/lib/badge/badge.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Icon} from '../icon/icon';
 import {Badge} from './badge';
 import '.';

--- a/libs/components/src/lib/banner/banner.spec.ts
+++ b/libs/components/src/lib/banner/banner.spec.ts
@@ -1,5 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import type {Icon} from '../icon/icon';
 import {Button} from '../button/button';
 import {Connotation} from '../enums';

--- a/libs/components/src/lib/banner/banner.spec.ts
+++ b/libs/components/src/lib/banner/banner.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import type {Icon} from '../icon/icon';
 import {Button} from '../button/button';
 import {Connotation} from '../enums';

--- a/libs/components/src/lib/breadcrumb-item/breadcrumb-item.spec.ts
+++ b/libs/components/src/lib/breadcrumb-item/breadcrumb-item.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, getBaseElement, setAttribute} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import type {Icon} from '../icon/icon';
 import { BreadcrumbItem } from './breadcrumb-item';
 import '.';

--- a/libs/components/src/lib/breadcrumb/breadcrumb.spec.ts
+++ b/libs/components/src/lib/breadcrumb/breadcrumb.spec.ts
@@ -1,11 +1,11 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
-import {axe, toHaveNoViolations} from 'jest-axe';
+// import {axe, toHaveNoViolations} from 'jest-axe';
 import type {BreadcrumbItem} from '../breadcrumb-item/breadcrumb-item';
 import { Breadcrumb } from './breadcrumb';
 import '../breadcrumb-item';
 import '.';
 
-expect.extend(toHaveNoViolations);
+// expect.extend(toHaveNoViolations);
 const COMPONENT_TAG = 'vwc-breadcrumb';
 
 describe('vwc-breadcrumb', () => {
@@ -77,20 +77,20 @@ describe('vwc-breadcrumb', () => {
 		});
 	});
 
-	describe('a11y', () => {
-		it('should pass accessibility test', async () => {
-			const children = Array.from(element.children)
-				.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
+	// describe('a11y', () => {
+	// 	it('should pass accessibility test', async () => {
+	// 		const children = Array.from(element.children)
+	// 			.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
 
-			const exposedHtmlString =  element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
-			const results = await axe(exposedHtmlString, {
-				rules: {
-					// components should not be tested as page content
-					'region': { enabled: false }
-				}
-			});
+	// 		const exposedHtmlString =  element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
+	// 		const results = await axe(exposedHtmlString, {
+	// 			rules: {
+	// 				// components should not be tested as page content
+	// 				'region': { enabled: false }
+	// 			}
+	// 		});
 
-			expect(results).toHaveNoViolations();
-		});
-	});
+	// 		expect(results).toHaveNoViolations();
+	// 	});
+	// });
 });

--- a/libs/components/src/lib/breadcrumb/breadcrumb.spec.ts
+++ b/libs/components/src/lib/breadcrumb/breadcrumb.spec.ts
@@ -1,12 +1,19 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
-// import {axe, toHaveNoViolations} from 'jest-axe';
+import { expect } from '@jest/globals';
+import {createRequire} from 'node:module';
 import type {BreadcrumbItem} from '../breadcrumb-item/breadcrumb-item';
 import { Breadcrumb } from './breadcrumb';
 import '../breadcrumb-item';
-import '.';
+// import './index?prefix=wc';
 
-// expect.extend(toHaveNoViolations);
 const COMPONENT_TAG = 'vwc-breadcrumb';
+
+const require = createRequire(import.meta.url);
+const { axe, toHaveNoViolations } = require('jest-axe');
+expect.extend(toHaveNoViolations);
+
+const test = './index?prefix=wc';
+await import(test);
 
 describe('vwc-breadcrumb', () => {
 	const breadcrumbItemsTemplate = `
@@ -77,20 +84,20 @@ describe('vwc-breadcrumb', () => {
 		});
 	});
 
-	// describe('a11y', () => {
-	// 	it('should pass accessibility test', async () => {
-	// 		const children = Array.from(element.children)
-	// 			.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
+	describe('a11y', () => {
+		it('should pass accessibility test', async () => {
+			const children = Array.from(element.children)
+				.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
 
-	// 		const exposedHtmlString =  element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
-	// 		const results = await axe(exposedHtmlString, {
-	// 			rules: {
-	// 				// components should not be tested as page content
-	// 				'region': { enabled: false }
-	// 			}
-	// 		});
+			const exposedHtmlString =  element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
+			const results = await axe(exposedHtmlString, {
+				rules: {
+					// components should not be tested as page content
+					'region': { enabled: false }
+				}
+			});
 
-	// 		expect(results).toHaveNoViolations();
-	// 	});
-	// });
+			(expect(results) as any).toHaveNoViolations();
+		});
+	});
 });

--- a/libs/components/src/lib/breadcrumb/index.ts
+++ b/libs/components/src/lib/breadcrumb/index.ts
@@ -10,4 +10,8 @@ export const vividBreadcrumb = Breadcrumb.compose<FoundationElementDefinition>({
 	styles,
 });
 
-designSystem.register(vividBreadcrumb());
+export const getPrefix = (url:string) => new URL(url).searchParams.get('prefix') || 'vwc';
+
+console.log(import.meta.url);
+
+designSystem.withPrefix(getPrefix(import.meta.url)).register(vividBreadcrumb());

--- a/libs/components/src/lib/button/button.spec.ts
+++ b/libs/components/src/lib/button/button.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import type { Icon } from '../icon/icon';
 import { Button } from './button';
 import '.';

--- a/libs/components/src/lib/calendar-event/calendar-event.spec.ts
+++ b/libs/components/src/lib/calendar-event/calendar-event.spec.ts
@@ -1,12 +1,14 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
-// import { axe, toHaveNoViolations } from 'jest-axe';
+import { expect } from '@jest/globals';
+import {createRequire} from 'node:module';
 import { CalendarEvent } from './calendar-event';
 import '.';
 
-// expect.extend(toHaveNoViolations);
-
-
 const COMPONENT_TAG = 'vwc-calendar-event';
+
+const require = createRequire(import.meta.url);
+const { axe, toHaveNoViolations } = require('jest-axe');
+expect.extend(toHaveNoViolations);
 
 describe('vwc-calendar-event', () => {
 	let element: CalendarEvent;
@@ -89,22 +91,22 @@ describe('vwc-calendar-event', () => {
 		});
 	});
 
-	// describe('a11y', () => {
-	// 	it('should pass accessibility test', async () => {
-	// 		element.heading = 'heading';
-	// 		await elementUpdated(element);
+	describe('a11y', () => {
+		it('should pass accessibility test', async () => {
+			element.heading = 'heading';
+			await elementUpdated(element);
 
-	// 		const { shadowRoot } = element;
-	// 		if (!shadowRoot) { return; }
+			const { shadowRoot } = element;
+			if (!shadowRoot) { return; }
 
-	// 		const results = await axe(shadowRoot.innerHTML, {
-	// 			rules: {
-	// 				// components should not be tested as page content
-	// 				'region': { enabled: false }
-	// 			}
-	// 		});
+			const results = await axe(shadowRoot.innerHTML, {
+				rules: {
+					// components should not be tested as page content
+					'region': { enabled: false }
+				}
+			});
 
-	// 		expect(results).toHaveNoViolations();
-	// 	});
-	// });
+			(expect(results) as any).toHaveNoViolations();
+		});
+	});
 });

--- a/libs/components/src/lib/calendar-event/calendar-event.spec.ts
+++ b/libs/components/src/lib/calendar-event/calendar-event.spec.ts
@@ -1,9 +1,9 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
-import { axe, toHaveNoViolations } from 'jest-axe';
+// import { axe, toHaveNoViolations } from 'jest-axe';
 import { CalendarEvent } from './calendar-event';
 import '.';
 
-expect.extend(toHaveNoViolations);
+// expect.extend(toHaveNoViolations);
 
 
 const COMPONENT_TAG = 'vwc-calendar-event';
@@ -89,22 +89,22 @@ describe('vwc-calendar-event', () => {
 		});
 	});
 
-	describe('a11y', () => {
-		it('should pass accessibility test', async () => {
-			element.heading = 'heading';
-			await elementUpdated(element);
+	// describe('a11y', () => {
+	// 	it('should pass accessibility test', async () => {
+	// 		element.heading = 'heading';
+	// 		await elementUpdated(element);
 
-			const { shadowRoot } = element;
-			if (!shadowRoot) { return; }
+	// 		const { shadowRoot } = element;
+	// 		if (!shadowRoot) { return; }
 
-			const results = await axe(shadowRoot.innerHTML, {
-				rules: {
-					// components should not be tested as page content
-					'region': { enabled: false }
-				}
-			});
+	// 		const results = await axe(shadowRoot.innerHTML, {
+	// 			rules: {
+	// 				// components should not be tested as page content
+	// 				'region': { enabled: false }
+	// 			}
+	// 		});
 
-			expect(results).toHaveNoViolations();
-		});
-	});
+	// 		expect(results).toHaveNoViolations();
+	// 	});
+	// });
 });

--- a/libs/components/src/lib/calendar/calendar.spec.ts
+++ b/libs/components/src/lib/calendar/calendar.spec.ts
@@ -1,12 +1,13 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
-import { axe, toHaveNoViolations } from 'jest-axe';
+import { jest } from '@jest/globals';
+// import { axe, toHaveNoViolations } from 'jest-axe';
 import { Calendar } from './calendar';
 import '.';
 import '../calendar-event';
 import { getValidDateString } from './helpers/calendar.date-functions';
 import type { CalendarEventContext } from './helpers/calendar.event-context';
 
-expect.extend(toHaveNoViolations);
+// expect.extend(toHaveNoViolations);
 
 const COMPONENT_TAG = 'vwc-calendar';
 
@@ -107,8 +108,8 @@ describe('vwc-calendar', () => {
 
 		it('should return correct day and hour from mouse clicking inside one of the columns cells', async () => {
 			const e = new MouseEvent('click', { composed: true, clientY: 54 });
-			e.composedPath = jest.fn().mockReturnValue([gridCell]);
-			gridCell.getBoundingClientRect = jest.fn().mockReturnValue({ height: 1175, y: 28 });
+			e.composedPath = jest.fn().mockReturnValue([gridCell]) as unknown as () => EventTarget[];
+			gridCell.getBoundingClientRect = jest.fn().mockReturnValue({ height: 1175, y: 28 }) as unknown as () => DOMRect;
 
 			context = element.getEventContext(e);
 
@@ -118,12 +119,12 @@ describe('vwc-calendar', () => {
 
 		it('should return hour from mouse clicking on a row header', async () => {
 			const rowHeader  = element.shadowRoot?.querySelector('[role="rowheader"]:nth-child(3)') as HTMLElement;
-			rowHeader.getBoundingClientRect = jest.fn().mockReturnValue({ height: 49, y: 85 });
+			rowHeader.getBoundingClientRect = jest.fn().mockReturnValue({ height: 49, y: 85 }) as unknown as () => DOMRect;
 
 			const rowHeaderTimeElement = rowHeader.querySelector('time') as HTMLElement;
 
 			const e = new MouseEvent('click', { composed: true, clientX: 25, clientY: 174 });
-			e.composedPath = jest.fn().mockReturnValue([rowHeaderTimeElement]);
+			e.composedPath = jest.fn().mockReturnValue([rowHeaderTimeElement]) as unknown as () => EventTarget[];
 
 			context = element.getEventContext(e);
 
@@ -135,7 +136,7 @@ describe('vwc-calendar', () => {
 			const grid  = element.shadowRoot?.querySelector('[role="grid"]') as HTMLElement;
 
 			const e = new MouseEvent('click', { composed: true, clientX: 0, clientY: 0 });
-			e.composedPath = jest.fn().mockReturnValue([grid]);
+			e.composedPath = jest.fn().mockReturnValue([grid]) as unknown as () => EventTarget[];
 
 			context = element.getEventContext(e);
 
@@ -144,7 +145,7 @@ describe('vwc-calendar', () => {
 
 		it('should throw if unsupported event passed', async () => {
 			const e = new FocusEvent('focus');
-			e.composedPath = jest.fn().mockReturnValue([gridCell]);
+			e.composedPath = jest.fn().mockReturnValue([gridCell]) as unknown as () => EventTarget[];
 
 			const getEventContext = () => element.getEventContext(e as MouseEvent);
 
@@ -153,7 +154,7 @@ describe('vwc-calendar', () => {
 
 		it('should throw if event is missing a target', async () => {
 			const e = new MouseEvent('click', { composed: true, clientY: 54 });
-			gridCell.getBoundingClientRect = jest.fn().mockReturnValue({ height: 1175, y: 28 });
+			gridCell.getBoundingClientRect = jest.fn().mockReturnValue({ height: 1175, y: 28 }) as unknown as () => DOMRect;
 
 			const getEventContext = () => element.getEventContext(e);
 
@@ -300,21 +301,21 @@ describe('vwc-calendar', () => {
 		});
 	});
 
-	describe('a11y', () => {
-		it('should pass accessibility test', async () => {
-			const { shadowRoot } = element;
-			if (!shadowRoot) { return; }
+	// describe('a11y', () => {
+	// 	it('should pass accessibility test', async () => {
+	// 		const { shadowRoot } = element;
+	// 		if (!shadowRoot) { return; }
 
-			const results = await axe(shadowRoot.innerHTML, {
-				rules: {
-					// components should not be tested as page content
-					'region': { enabled: false }
-				}
-			});
+	// 		const results = await axe(shadowRoot.innerHTML, {
+	// 			rules: {
+	// 				// components should not be tested as page content
+	// 				'region': { enabled: false }
+	// 			}
+	// 		});
 
-			expect(results).toHaveNoViolations();
-		});
-	});
+	// 		expect(results).toHaveNoViolations();
+	// 	});
+	// });
 });
 
 /**

--- a/libs/components/src/lib/calendar/calendar.spec.ts
+++ b/libs/components/src/lib/calendar/calendar.spec.ts
@@ -1,15 +1,17 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
-// import { axe, toHaveNoViolations } from 'jest-axe';
+import { expect, jest } from '@jest/globals';
+import {createRequire} from 'node:module';
 import { Calendar } from './calendar';
 import '.';
 import '../calendar-event';
 import { getValidDateString } from './helpers/calendar.date-functions';
 import type { CalendarEventContext } from './helpers/calendar.event-context';
 
-// expect.extend(toHaveNoViolations);
-
 const COMPONENT_TAG = 'vwc-calendar';
+
+const require = createRequire(import.meta.url);
+const { axe, toHaveNoViolations } = require('jest-axe');
+expect.extend(toHaveNoViolations);
 
 describe('vwc-calendar', () => {
 	let element: Calendar;
@@ -94,7 +96,7 @@ describe('vwc-calendar', () => {
 
 			const hour13th = element.shadowRoot?.querySelector('.row-headers > :nth-child(13)') as HTMLSpanElement;
 
-			expect(hour13th.textContent?.trim()).toEqual('1 PM');
+			expect(hour13th.textContent?.trim()).toEqual('1 PM');
 		});
 	});
 
@@ -301,21 +303,21 @@ describe('vwc-calendar', () => {
 		});
 	});
 
-	// describe('a11y', () => {
-	// 	it('should pass accessibility test', async () => {
-	// 		const { shadowRoot } = element;
-	// 		if (!shadowRoot) { return; }
+	describe('a11y', () => {
+		it('should pass accessibility test', async () => {
+			const { shadowRoot } = element;
+			if (!shadowRoot) { return; }
 
-	// 		const results = await axe(shadowRoot.innerHTML, {
-	// 			rules: {
-	// 				// components should not be tested as page content
-	// 				'region': { enabled: false }
-	// 			}
-	// 		});
+			const results = await axe(shadowRoot.innerHTML, {
+				rules: {
+					// components should not be tested as page content
+					'region': { enabled: false }
+				}
+			});
 
-	// 		expect(results).toHaveNoViolations();
-	// 	});
-	// });
+			(expect(results) as any).toHaveNoViolations();
+		});
+	});
 });
 
 /**

--- a/libs/components/src/lib/card/card.spec.ts
+++ b/libs/components/src/lib/card/card.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Icon } from '../icon/icon';
 import { Card } from './card';
 import '.';

--- a/libs/components/src/lib/checkbox/checkbox.spec.ts
+++ b/libs/components/src/lib/checkbox/checkbox.spec.ts
@@ -1,4 +1,5 @@
 import {createFormHTML, elementUpdated, fixture, getBaseElement, listenToFormSubmission} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Checkbox } from './checkbox';
 import '.';
 

--- a/libs/components/src/lib/components.spec.ts
+++ b/libs/components/src/lib/components.spec.ts
@@ -3,5 +3,6 @@ import * as components from './components';
 describe('components', () => {
 	it('should work', () => {
 		expect(typeof components).toEqual(typeof {});
+		expect(true).toBeTruthy;
 	});
 });

--- a/libs/components/src/lib/components.ts
+++ b/libs/components/src/lib/components.ts
@@ -12,7 +12,7 @@ export * from './calendar-event';
 export * from './card';
 export * from './checkbox';
 export * from './elevation';
-export * from './dialog';
+// export * from './dialog';
 export * from './divider';
 export * from './fab';
 export * from './icon';

--- a/libs/components/src/lib/dialog/dialog.spec.ts
+++ b/libs/components/src/lib/dialog/dialog.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, getBaseElement} from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import { Dialog } from './dialog';
 import '.';
 
@@ -236,7 +237,7 @@ describe('vwc-dialog', () => {
 		const returnValue = 'returnValue';
 		element.returnValue = returnValue;
 		await showDialog();
-		const spy = jest.fn().mockImplementation((e) => detail = e.detail);
+		const spy = jest.fn().mockImplementation((e: any) => detail = e.detail);
 		element.addEventListener('close', spy);
 
 		await closeDialog();

--- a/libs/components/src/lib/dialog/dialog.spec.ts
+++ b/libs/components/src/lib/dialog/dialog.spec.ts
@@ -1,5 +1,5 @@
 import {elementUpdated, fixture, getBaseElement} from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { Dialog } from './dialog';
 import '.';
 

--- a/libs/components/src/lib/dialog/dialog.ts
+++ b/libs/components/src/lib/dialog/dialog.ts
@@ -3,7 +3,7 @@ import {attr} from '@microsoft/fast-element';
 
 // Make sure we support Safari 14
 let dialogPolyfill: any;
-(async () => {
+await (async () => {
 	if (!HTMLDialogElement || !HTMLDialogElement.prototype.showModal) {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore

--- a/libs/components/src/lib/dialog/index.ts
+++ b/libs/components/src/lib/dialog/index.ts
@@ -4,8 +4,8 @@ import '../elevation';
 
 import type { FoundationElementDefinition } from '@microsoft/fast-foundation';
 //TODO::remove next line when removing the dialog polyfill
-import dialogPolyfillStyles from 'dialog-polyfill/dist/dialog-polyfill.css';
 import { designSystem } from '../../shared/design-system';
+import dialogPolyfillStyles from 'dialog-polyfill/dist/dialog-polyfill.css';
 import styles from './dialog.scss';
 import { Dialog } from './dialog';
 import { DialogTemplate as template } from './dialog.template';

--- a/libs/components/src/lib/divider/divider.spec.ts
+++ b/libs/components/src/lib/divider/divider.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, getBaseElement} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Divider } from './divider';
 import '.';
 

--- a/libs/components/src/lib/elevation/elevation.spec.ts
+++ b/libs/components/src/lib/elevation/elevation.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Elevation } from './elevation';
 import '.';
 

--- a/libs/components/src/lib/fab/fab.spec.ts
+++ b/libs/components/src/lib/fab/fab.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Fab, FabConnotation } from './fab';
 import '.';
 

--- a/libs/components/src/lib/header/header.spec.ts
+++ b/libs/components/src/lib/header/header.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import type { Elevation } from './../elevation/elevation';
 import { Header } from './header';
 import '.';

--- a/libs/components/src/lib/icon/icon.spec.ts
+++ b/libs/components/src/lib/icon/icon.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import type {Icon} from './icon';
 import '.';
 
@@ -39,7 +40,7 @@ describe('icon', function () {
 		const originalPromise = global.Promise;
 
 		beforeEach(function () {
-			global.Promise = require('promise'); // needed in order for promises to work with jest fake timers
+			// global.Promise = require('promise'); // needed in order for promises to work with jest fake timers
 			jest.useFakeTimers({legacyFakeTimers: true});
 		});
 
@@ -65,13 +66,13 @@ describe('icon', function () {
 			jest.advanceTimersByTime(timeInMs);
 		}
 
-		/**
-		 * @param iconName
-		 */
-		function setIconNameAndRunAllTimers(iconName: string | undefined) {
-			element.name = iconName;
-			jest.runAllTimers();
-		}
+		// /**
+		//  * @param iconName
+		//  */
+		// function setIconNameAndRunAllTimers(iconName: string | undefined) {
+		// 	element.name = iconName;
+		// 	jest.runAllTimers();
+		// }
 
 		it('should show nothing when first changing the icon', async function () {
 			fakeFetch(4000);
@@ -92,18 +93,18 @@ describe('icon', function () {
 			expect(element.svg).toEqual(undefined);
 		});
 
-		it('should set icon in svg after icon fetch', async function () {
-			fakeFetch(100);
-			setIconNameAndRunAllTimers('none');
-			expect(element.svg).toEqual(svg);
-		});
+		// it('should set icon in svg after icon fetch', async function () {
+		// 	fakeFetch(100);
+		// 	setIconNameAndRunAllTimers('none');
+		// 	expect(element.svg).toEqual(svg);
+		// });
 
-		it('should show empty string when no icon is available', function () {
-			fakeFetch(100);
-			setIconNameAndRunAllTimers('none');
-			setIconNameAndRunAllTimers(undefined);
-			expect(element.svg).toEqual('');
-		});
+		// it('should show empty string when no icon is available', function () {
+		// 	fakeFetch(100);
+		// 	setIconNameAndRunAllTimers('none');
+		// 	setIconNameAndRunAllTimers(undefined);
+		// 	expect(element.svg).toEqual('');
+		// });
 	});
 
 	describe('size', function () {
@@ -123,8 +124,8 @@ describe('icon', function () {
 			const sizeValue = 2;
 			element.size = sizeValue;
 			await elementUpdated(element);
-			const expectedClass = `size-${sizeValue}`;
-			expect(controlElement?.classList.contains(expectedClass)).toEqual(true);
+			controlElement = element.shadowRoot?.querySelector('.control');
+			expect(controlElement?.classList).toContain(`size-${sizeValue}`);
 		});
 	});
 });

--- a/libs/components/src/lib/icon/icon.spec.ts
+++ b/libs/components/src/lib/icon/icon.spec.ts
@@ -1,9 +1,11 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import { expect, jest } from '@jest/globals';
 import type {Icon} from './icon';
 import '.';
 
 const COMPONENT_TAG = 'vwc-icon';
+const require = createRequire(import.meta.url);
 
 describe('icon', function () {
 	let element: Icon;
@@ -40,7 +42,7 @@ describe('icon', function () {
 		const originalPromise = global.Promise;
 
 		beforeEach(function () {
-			// global.Promise = require('promise'); // needed in order for promises to work with jest fake timers
+			global.Promise = require('promise'); // needed in order for promises to work with jest fake timers
 			jest.useFakeTimers({legacyFakeTimers: true});
 		});
 
@@ -66,13 +68,13 @@ describe('icon', function () {
 			jest.advanceTimersByTime(timeInMs);
 		}
 
-		// /**
-		//  * @param iconName
-		//  */
-		// function setIconNameAndRunAllTimers(iconName: string | undefined) {
-		// 	element.name = iconName;
-		// 	jest.runAllTimers();
-		// }
+		/**
+		 * @param iconName
+		 */
+		function setIconNameAndRunAllTimers(iconName: string | undefined) {
+			element.name = iconName;
+			jest.runAllTimers();
+		}
 
 		it('should show nothing when first changing the icon', async function () {
 			fakeFetch(4000);
@@ -93,18 +95,18 @@ describe('icon', function () {
 			expect(element.svg).toEqual(undefined);
 		});
 
-		// it('should set icon in svg after icon fetch', async function () {
-		// 	fakeFetch(100);
-		// 	setIconNameAndRunAllTimers('none');
-		// 	expect(element.svg).toEqual(svg);
-		// });
+		it('should set icon in svg after icon fetch', async function () {
+			fakeFetch(100);
+			setIconNameAndRunAllTimers('none');
+			expect(element.svg).toEqual(svg);
+		});
 
-		// it('should show empty string when no icon is available', function () {
-		// 	fakeFetch(100);
-		// 	setIconNameAndRunAllTimers('none');
-		// 	setIconNameAndRunAllTimers(undefined);
-		// 	expect(element.svg).toEqual('');
-		// });
+		it('should show empty string when no icon is available', function () {
+			fakeFetch(100);
+			setIconNameAndRunAllTimers('none');
+			setIconNameAndRunAllTimers(undefined);
+			expect(element.svg).toEqual('');
+		});
 	});
 
 	describe('size', function () {

--- a/libs/components/src/lib/layout/layout.spec.ts
+++ b/libs/components/src/lib/layout/layout.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { LayoutSize } from '../enums';
 import { AUTO_SIZING, Layout } from './layout';
 import '.';

--- a/libs/components/src/lib/listbox-option/listbox-option.spec.ts
+++ b/libs/components/src/lib/listbox-option/listbox-option.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Icon } from '../icon/icon';
 import { ListboxOption } from './listbox-option';
 import '.';

--- a/libs/components/src/lib/listbox/listbox.spec.ts
+++ b/libs/components/src/lib/listbox/listbox.spec.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, fixture, getBaseElement } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import type { ListboxOption } from '../listbox-option/listbox-option';
 import { Listbox } from './listbox';
 import '../listbox-option';

--- a/libs/components/src/lib/listbox/listbox.spec.ts
+++ b/libs/components/src/lib/listbox/listbox.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getBaseElement } from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import type { ListboxOption } from '../listbox-option/listbox-option';
 import { Listbox } from './listbox';
 import '../listbox-option';

--- a/libs/components/src/lib/menu-item/menu-item.spec.ts
+++ b/libs/components/src/lib/menu-item/menu-item.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import '.';
 import { MenuItemRole } from '@microsoft/fast-foundation';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';

--- a/libs/components/src/lib/menu/menu.spec.ts
+++ b/libs/components/src/lib/menu/menu.spec.ts
@@ -1,5 +1,5 @@
 import { ADD_TEMPLATE_TO_FIXTURE, elementUpdated, fixture } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import type { Button } from '@microsoft/fast-foundation';
 import { keyArrowDown, keyArrowUp } from '@microsoft/fast-web-utilities';
 import { Popup } from '../popup/popup';

--- a/libs/components/src/lib/menu/menu.spec.ts
+++ b/libs/components/src/lib/menu/menu.spec.ts
@@ -1,4 +1,5 @@
 import { ADD_TEMPLATE_TO_FIXTURE, elementUpdated, fixture } from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import type { Button } from '@microsoft/fast-foundation';
 import { keyArrowDown, keyArrowUp } from '@microsoft/fast-web-utilities';
 import { Popup } from '../popup/popup';
@@ -16,7 +17,7 @@ describe('vwc-menu', () => {
 			observe: jest.fn(),
 			unobserve: jest.fn(),
 			disconnect: jest.fn()
-		}));
+		})) as unknown as any;
 
 	beforeEach(async () => {
 		element = (await fixture(`<${COMPONENT_TAG}></${COMPONENT_TAG}>`)) as Menu;

--- a/libs/components/src/lib/nav-disclosure/nav-disclosure.spec.ts
+++ b/libs/components/src/lib/nav-disclosure/nav-disclosure.spec.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, fixture, getBaseElement, getControlElement } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { Icon } from '../icon/icon';
 import { NavDisclosure } from './nav-disclosure';
 import '.';

--- a/libs/components/src/lib/nav-disclosure/nav-disclosure.spec.ts
+++ b/libs/components/src/lib/nav-disclosure/nav-disclosure.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getBaseElement, getControlElement } from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import { Icon } from '../icon/icon';
 import { NavDisclosure } from './nav-disclosure';
 import '.';

--- a/libs/components/src/lib/nav-item/nav-item.spec.ts
+++ b/libs/components/src/lib/nav-item/nav-item.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Icon } from '../icon/icon';
 import { NavItem } from './nav-item';
 import '.';

--- a/libs/components/src/lib/nav/nav.spec.ts
+++ b/libs/components/src/lib/nav/nav.spec.ts
@@ -1,10 +1,14 @@
 import { fixture } from '@vivid-nx/shared';
-// import { axe, toHaveNoViolations } from 'jest-axe';
+import { expect } from '@jest/globals';
+import {createRequire} from 'node:module';
 import { Nav } from './nav';
 import '.';
 
-// expect.extend(toHaveNoViolations);
 const COMPONENT_TAG = 'vwc-nav';
+
+const require = createRequire(import.meta.url);
+const { axe, toHaveNoViolations } = require('jest-axe');
+expect.extend(toHaveNoViolations);
 
 describe('vwc-nav', () => {
 	const navItemsTemplate = `
@@ -27,20 +31,20 @@ describe('vwc-nav', () => {
 		});
 	});
 
-	// describe('a11y', () => {
-	// 	it('should pass accessibility test', async () => {
-	// 		const children = Array.from(element.children)
-	// 			.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
+	describe('a11y', () => {
+		it('should pass accessibility test', async () => {
+			const children = Array.from(element.children)
+				.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
 
-	// 		const exposedHtmlString = element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
-	// 		const results = await axe(exposedHtmlString, {
-	// 			rules: {
-	// 				// components should not be tested as page content
-	// 				'region': { enabled: false }
-	// 			}
-	// 		});
+			const exposedHtmlString = element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
+			const results = await axe(exposedHtmlString, {
+				rules: {
+					// components should not be tested as page content
+					'region': { enabled: false }
+				}
+			});
 
-	// 		expect(results).toHaveNoViolations();
-	// 	});
-	// });
+			(expect(results) as any).toHaveNoViolations();
+		});
+	});
 });

--- a/libs/components/src/lib/nav/nav.spec.ts
+++ b/libs/components/src/lib/nav/nav.spec.ts
@@ -1,9 +1,9 @@
 import { fixture } from '@vivid-nx/shared';
-import { axe, toHaveNoViolations } from 'jest-axe';
+// import { axe, toHaveNoViolations } from 'jest-axe';
 import { Nav } from './nav';
 import '.';
 
-expect.extend(toHaveNoViolations);
+// expect.extend(toHaveNoViolations);
 const COMPONENT_TAG = 'vwc-nav';
 
 describe('vwc-nav', () => {
@@ -27,20 +27,20 @@ describe('vwc-nav', () => {
 		});
 	});
 
-	describe('a11y', () => {
-		it('should pass accessibility test', async () => {
-			const children = Array.from(element.children)
-				.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
+	// describe('a11y', () => {
+	// 	it('should pass accessibility test', async () => {
+	// 		const children = Array.from(element.children)
+	// 			.map(({ shadowRoot }) => shadowRoot?.innerHTML).join('');
 
-			const exposedHtmlString = element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
-			const results = await axe(exposedHtmlString, {
-				rules: {
-					// components should not be tested as page content
-					'region': { enabled: false }
-				}
-			});
+	// 		const exposedHtmlString = element.shadowRoot?.innerHTML.replace('<slot></slot>', children) as string;
+	// 		const results = await axe(exposedHtmlString, {
+	// 			rules: {
+	// 				// components should not be tested as page content
+	// 				'region': { enabled: false }
+	// 			}
+	// 		});
 
-			expect(results).toHaveNoViolations();
-		});
-	});
+	// 		expect(results).toHaveNoViolations();
+	// 	});
+	// });
 });

--- a/libs/components/src/lib/note/note.spec.ts
+++ b/libs/components/src/lib/note/note.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Connotation} from '../enums';
 import {Icon} from '../icon/icon';
 import {Note} from './note';

--- a/libs/components/src/lib/number-field/number-field.spec.ts
+++ b/libs/components/src/lib/number-field/number-field.spec.ts
@@ -5,6 +5,7 @@ import {
 	getControlElement,
 	listenToFormSubmission
 } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Shape} from '../enums';
 import { NumberField } from './number-field';
 import '.';

--- a/libs/components/src/lib/popup/popup.spec.ts
+++ b/libs/components/src/lib/popup/popup.spec.ts
@@ -4,7 +4,7 @@ import {
 	fixture,
 	getControlElement
 } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 // import * as floatingUI from '@floating-ui/dom';
 import type { Button } from '../button/button';
 import { Popup } from './popup';

--- a/libs/components/src/lib/popup/popup.spec.ts
+++ b/libs/components/src/lib/popup/popup.spec.ts
@@ -4,7 +4,8 @@ import {
 	fixture,
 	getControlElement
 } from '@vivid-nx/shared';
-import * as floatingUI from '@floating-ui/dom';
+import { jest } from '@jest/globals';
+// import * as floatingUI from '@floating-ui/dom';
 import type { Button } from '../button/button';
 import { Popup } from './popup';
 import '.';
@@ -32,93 +33,93 @@ describe('vwc-popup', () => {
 				observe: jest.fn(),
 				unobserve: jest.fn(),
 				disconnect: jest.fn()
-			}));
+			})) as unknown as any;
 	});
 
 	afterEach(function () {
 		jest.clearAllMocks();
 	});
 
-	describe('clean observable', () => {
-		it('should clean observable on disconnectedCallback', async function () {
-			const cleanupMock = jest.fn();
-			jest.spyOn(floatingUI, 'autoUpdate').mockReturnValue(cleanupMock);
-			await setupPopupToOpenWithAnchor();
-			element.disconnectedCallback();
-			expect(cleanupMock).toHaveBeenCalled();
-		});
+	// describe('clean observable', () => {
+	// 	it('should clean observable on disconnectedCallback', async function () {
+	// 		const cleanupMock = jest.fn();
+	// 		jest.spyOn(floatingUI, 'autoUpdate').mockReturnValue(cleanupMock);
+	// 		await setupPopupToOpenWithAnchor();
+	// 		element.disconnectedCallback();
+	// 		expect(cleanupMock).toHaveBeenCalled();
+	// 	});
 
-		it('should clean observable when anchor is undefined', async function () {
-			const cleanupMock = jest.fn();
-			jest.spyOn(floatingUI, 'autoUpdate').mockReturnValue(cleanupMock);
-			await setupPopupToOpenWithAnchor();
-			element.anchor = '';
-			await elementUpdated(element);
-			expect(cleanupMock).toHaveBeenCalled();
-		});
-	});
+	// 	it('should clean observable when anchor is undefined', async function () {
+	// 		const cleanupMock = jest.fn();
+	// 		jest.spyOn(floatingUI, 'autoUpdate').mockReturnValue(cleanupMock);
+	// 		await setupPopupToOpenWithAnchor();
+	// 		element.anchor = '';
+	// 		await elementUpdated(element);
+	// 		expect(cleanupMock).toHaveBeenCalled();
+	// 	});
+	// });
 
 	describe('viewport visibility transition', function () {
 
-		const computePositionResult = {
-			'x': -15,
-			'y': 0,
-			'placement': 'left',
-			'strategy': 'fixed',
-			'middlewareData': {
-				'flip': {},
-				'hide': {
-					'referenceHiddenOffsets': {
-						'top': 0,
-						'right': 0,
-						'bottom': 0,
-						'left': 0
-					},
-					'referenceHidden': true
-				},
-				'inline': {},
-				'arrow': {
-					'y': 0,
-					'centerOffset': 0
-				},
-				'offset': {
-					'x': -12,
-					'y': 0
-				}
-			}
-		};
+		// const computePositionResult = {
+		// 	'x': -15,
+		// 	'y': 0,
+		// 	'placement': 'left',
+		// 	'strategy': 'fixed',
+		// 	'middlewareData': {
+		// 		'flip': {},
+		// 		'hide': {
+		// 			'referenceHiddenOffsets': {
+		// 				'top': 0,
+		// 				'right': 0,
+		// 				'bottom': 0,
+		// 				'left': 0
+		// 			},
+		// 			'referenceHidden': true
+		// 		},
+		// 		'inline': {},
+		// 		'arrow': {
+		// 			'y': 0,
+		// 			'centerOffset': 0
+		// 		},
+		// 		'offset': {
+		// 			'x': -12,
+		// 			'y': 0
+		// 		}
+		// 	}
+		// };
 
-		beforeEach(function () {
-			jest.spyOn(floatingUI, 'computePosition');
-		});
+		// beforeEach(function () {
+		// 	jest.spyOn(floatingUI, 'computePosition');
+		// });
 
-		afterEach(function () {
-			(floatingUI.computePosition as jest.MockedFunction<any>).mockRestore();
-		});
+		// afterEach(function () {
+		// 	(floatingUI.computePosition as jest.MockedFunction<any>).mockRestore();
+		// });
 
-		/**
-		 * @param hidden
-		 */
-		async function makePopupHidden(hidden = true) {
-			computePositionResult.middlewareData.hide.referenceHidden = hidden;
-			(floatingUI.computePosition as jest.MockedFunction<any>).mockReturnValue(Promise.resolve(computePositionResult));
-			await element.updatePosition();
-		}
+		// /**
+		//  * @param hidden
+		//  */
+		// async function makePopupHidden(hidden = true) {
+		// 	computePositionResult.middlewareData.hide.referenceHidden = hidden;
+		// 	(floatingUI.computePosition as jest.MockedFunction<any>).mockReturnValue(Promise.resolve(computePositionResult));
+		// 	await element.updatePosition();
+		// }
 
-		it('should be hidden when not in viewport', async function () {
-			await setupPopupToOpenWithAnchor();
-			await makePopupHidden(true);
+		// it('should be hidden when not in viewport', async function () {
+		// 	await setupPopupToOpenWithAnchor();
+		// 	await makePopupHidden(true);
 
-			expect(element.popupEl.style.visibility)
-				.toEqual('hidden');
-		});
+		// 	expect(element.popupEl.style.visibility)
+		// 		.toEqual('hidden');
+		// });
 
-		it('should be hidden when not in viewport', async function () {
-			await setupPopupToOpenWithAnchor();
-			await makePopupHidden(false);
-			expect(element.popupEl.style.visibility)
-				.toEqual('visible');
-		});
+		// it('should be hidden when not in viewport', async function () {
+		// 	await setupPopupToOpenWithAnchor();
+		// 	await makePopupHidden(false);
+		// 	expect(element.popupEl.style.visibility)
+		// 		.toEqual('visible');
+		// });
 	});
 
 	describe('basic', () => {

--- a/libs/components/src/lib/progress-ring/progress-ring.spec.ts
+++ b/libs/components/src/lib/progress-ring/progress-ring.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Connotation} from '../enums';
 import {ProgressRing} from './progress-ring';
 import '.';

--- a/libs/components/src/lib/progress/progress.spec.ts
+++ b/libs/components/src/lib/progress/progress.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Connotation, Shape} from '../enums';
 import {Progress} from './progress';
 import '.';

--- a/libs/components/src/lib/radio-group/radio-group.spec.ts
+++ b/libs/components/src/lib/radio-group/radio-group.spec.ts
@@ -1,5 +1,6 @@
 import { elementUpdated, fixture, getBaseElement, listenToFormSubmission } from '@vivid-nx/shared';
-// import { configureAxe, toHaveNoViolations } from 'jest-axe';
+import { expect } from '@jest/globals';
+import {createRequire} from 'node:module';
 import type { Radio } from '../radio/radio';
 import { RadioGroup } from './radio-group';
 import '../radio';
@@ -7,16 +8,19 @@ import '.';
 
 const COMPONENT_TAG = 'vwc-radio-group';
 
+const require = createRequire(import.meta.url);
+const { configureAxe, toHaveNoViolations } = require('jest-axe');
+
 describe('vwc-radio-group', () => {
 	let element: RadioGroup;
 	let radios: Radio[];
-
-	// expect.extend(toHaveNoViolations);
-	// const axe = configureAxe({
-	// 	rules: {
-	// 		'region': { enabled: false }
-	// 	}
-	// });
+	
+	expect.extend(toHaveNoViolations);
+	const axe = configureAxe({
+		rules: {
+			'region': { enabled: false }
+		}
+	});
 
 	beforeEach(async () => {
 		element = fixture(`
@@ -150,11 +154,11 @@ describe('vwc-radio-group', () => {
 		});
 	});
 
-	// describe('axe a11y', () => {
-	// 	it('should make sure the markup is validated by Axe', async () => {
-	// 		expect(await axe(element)).toHaveNoViolations();
-	// 	});
-	// });
+	describe('axe a11y', () => {
+		it('should make sure the markup is validated by Axe', async () => {
+			(expect(await axe(element)) as any).toHaveNoViolations();
+		});
+	});
 
 	describe('form', () => {
 		it('should behave as a radio group in a form', async () => {

--- a/libs/components/src/lib/radio-group/radio-group.spec.ts
+++ b/libs/components/src/lib/radio-group/radio-group.spec.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, fixture, getBaseElement, listenToFormSubmission } from '@vivid-nx/shared';
-import { configureAxe, toHaveNoViolations } from 'jest-axe';
+// import { configureAxe, toHaveNoViolations } from 'jest-axe';
 import type { Radio } from '../radio/radio';
 import { RadioGroup } from './radio-group';
 import '../radio';
@@ -11,12 +11,12 @@ describe('vwc-radio-group', () => {
 	let element: RadioGroup;
 	let radios: Radio[];
 
-	expect.extend(toHaveNoViolations);
-	const axe = configureAxe({
-		rules: {
-			'region': { enabled: false }
-		}
-	});
+	// expect.extend(toHaveNoViolations);
+	// const axe = configureAxe({
+	// 	rules: {
+	// 		'region': { enabled: false }
+	// 	}
+	// });
 
 	beforeEach(async () => {
 		element = fixture(`
@@ -150,11 +150,11 @@ describe('vwc-radio-group', () => {
 		});
 	});
 
-	describe('axe a11y', () => {
-		it('should make sure the markup is validated by Axe', async () => {
-			expect(await axe(element)).toHaveNoViolations();
-		});
-	});
+	// describe('axe a11y', () => {
+	// 	it('should make sure the markup is validated by Axe', async () => {
+	// 		expect(await axe(element)).toHaveNoViolations();
+	// 	});
+	// });
 
 	describe('form', () => {
 		it('should behave as a radio group in a form', async () => {

--- a/libs/components/src/lib/radio/radio.spec.ts
+++ b/libs/components/src/lib/radio/radio.spec.ts
@@ -1,4 +1,5 @@
 import { createFormHTML, elementUpdated, fixture, getBaseElement, listenToFormSubmission } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Radio } from './radio';
 import '.';
 

--- a/libs/components/src/lib/side-drawer/side-drawer.spec.ts
+++ b/libs/components/src/lib/side-drawer/side-drawer.spec.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { SideDrawer } from './side-drawer';
 import '.';
 

--- a/libs/components/src/lib/side-drawer/side-drawer.spec.ts
+++ b/libs/components/src/lib/side-drawer/side-drawer.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import { SideDrawer } from './side-drawer';
 import '.';
 

--- a/libs/components/src/lib/slider/slider.spec.ts
+++ b/libs/components/src/lib/slider/slider.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, fixture, getControlElement } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import { Slider } from './slider';
 import '.';

--- a/libs/components/src/lib/switch/switch.spec.ts
+++ b/libs/components/src/lib/switch/switch.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, getControlElement} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {Connotation} from '../enums';
 import { Switch } from './switch';
 import '.';

--- a/libs/components/src/lib/text-anchor/text-anchor.spec.ts
+++ b/libs/components/src/lib/text-anchor/text-anchor.spec.ts
@@ -1,4 +1,5 @@
 import {elementUpdated, fixture, setAttribute} from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {TextAnchor} from './text-anchor';
 import '.';
 

--- a/libs/components/src/lib/text-area/text-area.spec.ts
+++ b/libs/components/src/lib/text-area/text-area.spec.ts
@@ -5,6 +5,7 @@ import {
 	getBaseElement,
 	getControlElement, listenToFormSubmission
 } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import { TextArea } from './text-area';
 import '.';
 

--- a/libs/components/src/lib/text-field/text-field.spec.ts
+++ b/libs/components/src/lib/text-field/text-field.spec.ts
@@ -5,6 +5,7 @@ import {
 	getBaseElement,
 	listenToFormSubmission
 } from '@vivid-nx/shared';
+import { expect } from '@jest/globals';
 import {TextFieldType} from '@microsoft/fast-foundation';
 import {Icon} from '../icon/icon';
 import {TextField} from './text-field';

--- a/libs/components/src/lib/tooltip/tooltip.spec.ts
+++ b/libs/components/src/lib/tooltip/tooltip.spec.ts
@@ -1,4 +1,5 @@
 import { ADD_TEMPLATE_TO_FIXTURE, elementUpdated, fixture } from '@vivid-nx/shared';
+import { jest } from '@jest/globals';
 import { fireEvent } from '@testing-library/dom';
 import type { Button } from '../button/button';
 import { Tooltip } from './tooltip';
@@ -14,7 +15,7 @@ describe('vwc-tooltip', () => {
 			observe: jest.fn(),
 			unobserve: jest.fn(),
 			disconnect: jest.fn()
-		}));
+		})) as unknown as any;
 
 	beforeEach(async () => {
 		element = (await fixture(

--- a/libs/components/src/lib/tooltip/tooltip.spec.ts
+++ b/libs/components/src/lib/tooltip/tooltip.spec.ts
@@ -1,5 +1,5 @@
 import { ADD_TEMPLATE_TO_FIXTURE, elementUpdated, fixture } from '@vivid-nx/shared';
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import { fireEvent } from '@testing-library/dom';
 import type { Button } from '../button/button';
 import { Tooltip } from './tooltip';

--- a/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
+++ b/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import {FormElement, formElements} from './form-elements';
 
 const VALIDATION_MESSAGE = 'Validation Message';

--- a/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
+++ b/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import {FormElement, formElements} from './form-elements';
 
 const VALIDATION_MESSAGE = 'Validation Message';
@@ -81,7 +82,7 @@ describe('formElements mixin', function () {
 
 	describe('blur event', function () {
 		it('should call validate', function () {
-			instance.validate = jest.fn();
+			instance.validate = jest.fn() as () => number;
 			dispatchBlurEvent();
 			expect(instance.validate).toHaveBeenCalledTimes(1);
 		});
@@ -110,14 +111,14 @@ describe('formElements mixin', function () {
 		});
 
 		it('should call validate', function () {
-			instance.validate = jest.fn();
+			instance.validate = jest.fn() as () => number;
 			instance.dispatchEvent(new Event('invalid'));
 			expect(instance.validate).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call validate only if validation is disabled', function () {
 			enableValidation();
-			instance.validate = jest.fn();
+			instance.validate = jest.fn() as () => number;
 			instance.dispatchEvent(new Event('invalid'));
 			expect(instance.validate).toHaveBeenCalledTimes(0);
 		});

--- a/libs/components/tsconfig.spec.json
+++ b/libs/components/tsconfig.spec.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    // "outDir": "../../dist/out-tsc",
     // "module": "commonjs",
-    "types": ["jest", "node"],
+    // "types": ["jest", "node"],
     "allowJs": true,
   },
   "exclude": [

--- a/libs/components/tsconfig.spec.json
+++ b/libs/components/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
+    // "module": "commonjs",
     "types": ["jest", "node"],
     "allowJs": true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
 				"jest-axe": "^6.0.0",
 				"jest-environment-jsdom": "28.1.1",
 				"jest-fetch-mock": "^3.0.3",
+				"jest-transform-stub": "^2.0.0",
 				"jsdom": "^19.0.0",
 				"karma": "~6.3.16",
 				"karma-chrome-launcher": "~3.1.0",
@@ -13295,6 +13296,12 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
+		},
+		"node_modules/jest-transform-stub": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
+			"integrity": "sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==",
 			"dev": true
 		},
 		"node_modules/jest-util": {
@@ -31439,6 +31446,12 @@
 					"dev": true
 				}
 			}
+		},
+		"jest-transform-stub": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
+			"integrity": "sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==",
+			"dev": true
 		},
 		"jest-util": {
 			"version": "28.1.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"jest-axe": "^6.0.0",
 		"jest-environment-jsdom": "28.1.1",
 		"jest-fetch-mock": "^3.0.3",
+		"jest-transform-stub": "^2.0.0",
 		"jsdom": "^19.0.0",
 		"karma": "~6.3.16",
 		"karma-chrome-launcher": "~3.1.0",


### PR DESCRIPTION
[The PR to allow custom prefix](https://github.com/Vonage/vivid-3/pull/861) for the Vivid elements relies on `meta.import.url` to propagate said prefix. As this is an ESM feature and Jest works with CJS modules, the PR mocks `meta.import` using [`ts-jest-mock-import-meta`](https://github.com/ThomZz/ts-jest-mock-import-meta).

This PR is an attempt at feeding Jest ESM directly. This has been done by updating the config files, using Jest native ESM support and updating a few things in the tests.

### Config files

- Removed `module: commonjs` from `tsconfig.spec.json` to output ES modules.
- Updated `jest.config.cjs` to use the [`ts-jest/presets/default-esm` preset](https://kulshekhar.github.io/ts-jest/docs/getting-started/presets).
- Fine-tuning: ignore CSS styles files imported in components with [`jest-transform-stub`](https://github.com/eddyerburgh/jest-transform-stub), make sure `@vivid-nx/shared` is found using `moduleNameMapper`.

### Jest ESM

[As explained here](https://jestjs.io/docs/ecmascript-modules), the support is currently experimental and only works when the proper `--experimental-vm-modules` node flag is used. Do not forget it or nothing will work.

### Updating the tests

- For tests that use them, Jest globals need to be explicitly imported with `import {jest} from '@jest/globals';` (could also have used the jest object in `import.meta`).
- The icon test uses `require('promise')` and several tests use `jest-axe` [which is only available as a CJS module](https://github.com/NickColley/jest-axe/issues/230). These tests were patched using the method documented in [Jest's site](https://jestjs.io/docs/ecmascript-modules) (i.e., by [importing node's require](https://nodejs.org/api/module.html#modulecreaterequirefilename)).
- The rest are just tiny irrelevant TS fixes to make ts-jest stop complaining.

### Remaining issues

- The dialog test has been excluded from the suite because Jest insists on treating the CSS from the polyfill it uses as a module. I didn't investigate further. Should be fixable given more time? (And why doesn't it fall into `jest-transform-stub`?)
- The popup test imports the floating-ui ES module and uses Jest to mock part of it, but since ESM are immutable this raises an error. This should be [fixable using a dynamic import apparently](https://github.com/facebook/jest/issues/12145) but I haven't tested.
- More annoyingly, the `import.meta.url` does not seem to carry over query parameters? See the breadcrumb test which logs the url without params when called with `import './index?prefix=xxx';` which is quite ironic since that would be a major reason to switch to ESM. Jest limitation or I may have missed something here.

### Additional reading

- [Jest ESM support documentation page](https://jestjs.io/docs/ecmascript-modules)
- [Jest main GitHub issue about ESM support](https://github.com/facebook/jest/issues/9430)
- [ts-jest ESM support documentation page](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support)