### PR TITLE
fix(calendar): brittle test character

### DIFF
--- a/change/@vonage-vivid-637c6085-f498-42ba-802c-c22a83faa806.json
+++ b/change/@vonage-vivid-637c6085-f498-42ba-802c-c22a83faa806.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update calendar.spec.ts",
+  "packageName": "@vonage/vivid",
+  "email": "olaf-k@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/libs/components/src/lib/calendar/calendar.spec.ts
+++ b/libs/components/src/lib/calendar/calendar.spec.ts
@@ -93,7 +93,8 @@ describe('vwc-calendar', () => {
 
 			const hour13th = element.shadowRoot?.querySelector('.row-headers > :nth-child(13)') as HTMLSpanElement;
 
-			expect(hour13th.textContent?.toLowerCase().trim()).toEqual('1 pm');
+			// Intl uses short non-breaking spaces or just spaces depending on the node version
+			expect(hour13th.textContent?.toLowerCase().trim()).toMatch(/1[\u202f\u0020]pm/);
 		});
 	});
 

--- a/libs/components/src/lib/calendar/calendar.spec.ts
+++ b/libs/components/src/lib/calendar/calendar.spec.ts
@@ -86,15 +86,17 @@ describe('vwc-calendar', () => {
 	});
 
 	describe('hour12', () => {
-		it('should set hebrew locales', async () => {
+		it('should display time in 12h format', async () => {
 			element.hour12 = true;
 
 			await elementUpdated(element);
 
 			const hour13th = element.shadowRoot?.querySelector('.row-headers > :nth-child(13)') as HTMLSpanElement;
 
-			// Intl uses short non-breaking spaces or just spaces depending on the node version
-			expect(hour13th.textContent?.toLowerCase().trim()).toMatch(/1[\u202f\u0020]pm/);
+			const expectedTimeString = new Intl.DateTimeFormat('en-US', {hour: 'numeric', hour12: true})
+				.format(new Date('2022-12-16T13:00:00.000'));
+
+			expect(hour13th.textContent?.trim()).toEqual(expectedTimeString);
 		});
 	});
 


### PR DESCRIPTION
followup of #913 

one of the tests is checking the result of `Intl.DateTimeFormat.format()` used to format an hour in AM/PM format against a hardcoded string.

the problem is that Intl seems to behave differently depending on the platform it is used in.
so far, experiments show that the character used to separate the hours number from the 'AM/PM' string is:
- a space in Chrome and Node pre-19
- a short non-breaking space in Node 19

this PR aims at making the test more resilient (and to stop failing on my machine)

(additionally, Chrome seems to output 'am/pm' on Mac and 'AM/PM' on Windows 😶) 