### PR TITLE
docs(site): support figma embeded components frame

### DIFF
--- a/apps/docs/_data/components.json
+++ b/apps/docs/_data/components.json
@@ -35,7 +35,8 @@
 		"modules": [
 			"/assets/modules/components/breadcrumb-item/index.js",
 			"/assets/modules/components/breadcrumb/index.js"
-		]
+		],
+		"figma": "https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2Fr8OYLPmRmDqfLKt6KHdJDB%2FVivid-UI-Kit---2.0%3Fnode-id%3D1968%253A616%26t%3DTQg9Vc4bTd00w4qw-1"
 	},
 	{
 		"title": "breadcrumb-item",

--- a/apps/docs/pages/component-pages.njk
+++ b/apps/docs/pages/component-pages.njk
@@ -23,4 +23,8 @@ permalink: "components/{{ component.title | slug }}/"
 
 {% block content %}
 	{% renderFile component.markdown %}
+
+	{% if component.figma %}
+	<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="100%" height="450" src="{{ component.figma }}" allowfullscreen></iframe>
+	{% endif %}
 {% endblock %}


### PR DESCRIPTION
introduces figma embeded frames to compliment components design information

blockers:

- Figma file is not visible to non Vonage Figma organization members. Vivid UI-Kit should be public
- This should better await #699 as this flow expected to be presented as the secondary tab