### PR TITLE
fix(webpack): compile error, unable to parse `?`

### DIFF
--- a/patches/@oddbird+popover-polyfill+0.0.3.patch
+++ b/patches/@oddbird+popover-polyfill+0.0.3.patch
@@ -335,7 +335,9 @@ index 46f6e4e..79dae38 100644
 +				visibleElements.add(this);
 +				if (this.popover === "auto") {
 +					const focusEl = this.hasAttribute("autofocus") ? this : this.querySelector("[autofocus]");
-+					focusEl?.focus();
++					if (focusEl) {
++						focusEl.focus();
++					}
 +				}
 +			}
 +		},


### PR DESCRIPTION
This line of code 
```diff
+					focusEl?.focus();
```
prevents webpack from bundling the vivid package

![image](https://user-images.githubusercontent.com/18071010/214018759-5acfd3c8-fd20-48df-a270-1fc03ced4f05.png)
