### PR TITLE
feat(styles): contain css rules within cascade layers

### DIFF
--- a/libs/styles/src/lib/core/theme.scss
+++ b/libs/styles/src/lib/core/theme.scss
@@ -1,7 +1,11 @@
 @use '../../../../..//dist/libs/tokens/scss/tokens.constants' as constants;
 
-.vvd-root {
-	color-scheme: var(#{constants.$vvd-color-scheme});
-	background-color: var(#{constants.$vvd-color-canvas});
-	color: var(#{constants.$vvd-color-canvas-text});
+
+@layer vivid.theme {
+	.vvd-root {
+		color-scheme: var(#{constants.$vvd-color-scheme});
+		background-color: var(#{constants.$vvd-color-canvas});
+		color: var(#{constants.$vvd-color-canvas-text});
+	}
 }
+

--- a/libs/styles/src/lib/core/typography.scss
+++ b/libs/styles/src/lib/core/typography.scss
@@ -16,84 +16,87 @@ $selectors: (
 	-moz-osx-font-smoothing: grayscale;  /* apply font anti-aliasing for Firefox on OSX */
 }
 
-.vvd-root {
-	&:root { // <--- When 'vvd-root' is set on the `:root` (html element), typeface sizes are able to descend from the root font-size, thus comply with the [WCAG 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text)
-		--vvd-size-font-scale-base: 1rem;
-		font-size: unset; // resolves to the user-agent default font size (generally 16px)
+@layer vivid.typography {
+	.vvd-root {
+		&:root { // <--- When 'vvd-root' is set on the `:root` (html element), typeface sizes are able to descend from the root font-size, thus comply with the [WCAG 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text)
+			--vvd-size-font-scale-base: 1rem;
+			font-size: unset; // resolves to the user-agent default font size (generally 16px)
 
-		> body {
+			> body {
+				@include typography-base;
+			}
+		}
+
+		&:not(:root) {
 			@include typography-base;
 		}
-	}
 
-	&:not(:root) {
-		@include typography-base;
-	}
-
-	p {
-		font: var(#{constants.$vvd-typography-base});
-		margin-block: 16px;
-	}
-
-	#{map.get($selectors, 'bold')} {
-		font: var(#{constants.$vvd-typography-base-bold});
-	}
-
-	#{map.get($selectors, 'code')} {
-		font: var(#{constants.$vvd-typography-base-code});
-	}
-
-	.headline {
-		font: var(#{constants.$vvd-typography-headline});
-		margin-block: 40px;
-	}
-
-	.subtitle {
-		font: var(#{constants.$vvd-typography-subtitle});
-		margin-block: 40px;
-	}
-
-	h1, .heading1 {
-		font: var(#{constants.$vvd-typography-heading-1});
-		margin-block: 32px;
-	}
-
-	h2, .heading2 {
-		font: var(#{constants.$vvd-typography-heading-2});
-		margin-block: 32px;
-	}
-
-	h3, .heading3 {
-		font: var(#{constants.$vvd-typography-heading-3});
-		margin-block: 24px;
-	}
-
-	h4, .heading4 {
-		font: var(#{constants.$vvd-typography-heading-4});
-		margin-block: 24px;
-	}
-
-	small, figcaption {
-		font: var(#{constants.$vvd-typography-base-condensed});
+		p {
+			font: var(#{constants.$vvd-typography-base});
+			margin-block: 16px;
+		}
 
 		#{map.get($selectors, 'bold')} {
-			font: var(#{constants.$vvd-typography-base-condensed-bold});
+			font: var(#{constants.$vvd-typography-base-bold});
+		}
+
+		#{map.get($selectors, 'code')} {
+			font: var(#{constants.$vvd-typography-base-code});
+		}
+
+		.headline {
+			font: var(#{constants.$vvd-typography-headline});
+			margin-block: 40px;
+		}
+
+		.subtitle {
+			font: var(#{constants.$vvd-typography-subtitle});
+			margin-block: 40px;
+		}
+
+		h1, .heading1 {
+			font: var(#{constants.$vvd-typography-heading-1});
+			margin-block: 32px;
+		}
+
+		h2, .heading2 {
+			font: var(#{constants.$vvd-typography-heading-2});
+			margin-block: 32px;
+		}
+
+		h3, .heading3 {
+			font: var(#{constants.$vvd-typography-heading-3});
+			margin-block: 24px;
+		}
+
+		h4, .heading4 {
+			font: var(#{constants.$vvd-typography-heading-4});
+			margin-block: 24px;
+		}
+
+		small, figcaption {
+			font: var(#{constants.$vvd-typography-base-condensed});
+
+			#{map.get($selectors, 'bold')} {
+				font: var(#{constants.$vvd-typography-base-condensed-bold});
+			}
+		}
+
+		sub,
+		sup {
+			font: 75%;
+			line-height: 0;
+			position: relative;
+			vertical-align: baseline;
+		}
+
+		sub {
+			bottom: -0.25em;
+		}
+
+		sup {
+			top: -0.5em;
 		}
 	}
-
-	sub,
-	sup {
-		font: 75%;
-		line-height: 0;
-		position: relative;
-		vertical-align: baseline;
-	}
-
-	sub {
-		bottom: -0.25em;
-	}
-
-	sup {
-		top: -0.5em;
-	}
 }
+

--- a/libs/styles/src/lib/tokens/theme-dark.scss
+++ b/libs/styles/src/lib/tokens/theme-dark.scss
@@ -5,13 +5,15 @@
 @use 'partials/variables' as variables;
 
 
-@include properties.properties;
+@layer vivid.theme {
+	@include properties.properties;
 
-#{variables.$theme-main-selector} {
-	@include dark.variables;
-	@include typography.variables;
-}
+	#{variables.$theme-main-selector} {
+		@include dark.variables;
+		@include typography.variables;
+	}
 
-#{variables.$theme-alternate-selector} {
-	@include light.variables;
+	#{variables.$theme-alternate-selector} {
+		@include light.variables;
+	}
 }

--- a/libs/styles/src/lib/tokens/theme-light.scss
+++ b/libs/styles/src/lib/tokens/theme-light.scss
@@ -5,13 +5,15 @@
 @use 'partials/variables' as variables;
 
 
-@include properties.properties;
+@layer vivid.theme {
+	@include properties.properties;
 
-#{variables.$theme-main-selector} {
-	@include light.variables;
-	@include typography.variables;
-}
+	#{variables.$theme-main-selector} {
+		@include light.variables;
+		@include typography.variables;
+	}
 
-#{variables.$theme-alternate-selector} {
-	@include dark.variables;
+	#{variables.$theme-alternate-selector} {
+		@include dark.variables;
+	}
 }


### PR DESCRIPTION
let authors take advantage of the cascade [`@layer statement`](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers#the_layer_statement_at-rule_for_named_layers) and set their preferred layers priority by containing vivid css rules within a specified `@layer`.

- [ ] must clarify conflict with Vivid@2.x tokens - https://github.com/Vonage/vivid-3/discussions/1010#discussioncomment-4887325
  - one feasible solution is to apply `revert-layer` value on conflicting rules, which will revert to a previous layer
  ```css
  .vivid-3-component {
     --vvd-color-neutral-50: revert-layer;
  }
   ```
- [ ] awaits #1007 to add relevant documentation