### PR TITLE
fix(public-contract): export public contract constant types

### DIFF
--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/components';
+export * from './lib/enums';
 export * from './shared/design-system';

--- a/libs/components/src/lib/accordion/definition.ts
+++ b/libs/components/src/lib/accordion/definition.ts
@@ -6,6 +6,8 @@ import styles from './accordion.scss';
 import { Accordion } from './accordion';
 import { AccordionTemplate as template } from './accordion.template';
 
+export type { AccordionExpandMode } from '@microsoft/fast-foundation'
+
 /**
  *
  * @internal

--- a/libs/components/src/lib/action-group/action-group.ts
+++ b/libs/components/src/lib/action-group/action-group.ts
@@ -22,7 +22,7 @@ Appearance.Filled | Appearance.Outlined | Appearance.Ghost>;
  *
  * @public
  */
-type ActionGroupShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type ActionGroupShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Base class for action-group

--- a/libs/components/src/lib/action-group/definition.ts
+++ b/libs/components/src/lib/action-group/definition.ts
@@ -5,6 +5,7 @@ import styles from './action-group.scss';
 import { ActionGroup } from './action-group';
 import { ActionGroupTemplate as template } from './action-group.template';
 
+export type { ActionGroupShape, ActionGroupAppearance } from './action-group'
 
 /**
  *

--- a/libs/components/src/lib/avatar/avatar.ts
+++ b/libs/components/src/lib/avatar/avatar.ts
@@ -28,7 +28,7 @@ Appearance.Filled | Appearance.Outlined>;
  *
  * @public
  */
-type AvatarShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type AvatarShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 /**
  * Base class for avatar
  *
@@ -40,7 +40,7 @@ type AvatarShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
  *
  * @public
  */
-type AvatarSize = Extract<Size, Size.Condensed | Size.Normal | Size.Expanded>;
+export type AvatarSize = Extract<Size, Size.Condensed | Size.Normal | Size.Expanded>;
 
 
 export class Avatar extends FoundationElement {

--- a/libs/components/src/lib/avatar/definition.ts
+++ b/libs/components/src/lib/avatar/definition.ts
@@ -6,6 +6,7 @@ import styles from './avatar.scss';
 import { Avatar } from './avatar';
 import { AvatarTemplate as template } from './avatar.template';
 
+export type { AvatarConnotation, AvatarShape, AvatarAppearance, AvatarSize } from './avatar'
 
 /**
  *

--- a/libs/components/src/lib/badge/badge.ts
+++ b/libs/components/src/lib/badge/badge.ts
@@ -11,7 +11,7 @@ import type {
  *
  * @public
  */
-type BadgeConnotation = Extract<Connotation,
+export type BadgeConnotation = Extract<Connotation,
 | Connotation.Accent
 | Connotation.CTA
 | Connotation.Success
@@ -24,7 +24,7 @@ type BadgeConnotation = Extract<Connotation,
  *
  * @public
  */
-type BadgeAppearance = Extract<Appearance,
+export type BadgeAppearance = Extract<Appearance,
 Appearance.Filled | Appearance.Duotone | Appearance.Subtle>;
 
 /**
@@ -32,7 +32,7 @@ Appearance.Filled | Appearance.Duotone | Appearance.Subtle>;
  *
  * @public
  */
-type BadgeShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type BadgeShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Base class for badge

--- a/libs/components/src/lib/badge/definition.ts
+++ b/libs/components/src/lib/badge/definition.ts
@@ -5,6 +5,7 @@ import { Badge } from './badge';
 import styles from './badge.scss';
 import { badgeTemplate as template } from './badge.template';
 
+export type { BadgeConnotation, BadgeAppearance, BadgeShape } from './badge'
 
 /**
  * Represents a badge custom element.

--- a/libs/components/src/lib/banner/definition.ts
+++ b/libs/components/src/lib/banner/definition.ts
@@ -7,6 +7,7 @@ import styles from './banner.scss';
 import { Banner } from './banner';
 import { BannerTemplate as template } from './banner.template';
 
+export type { BannerConnotation } from './banner'
 
 /**
  *

--- a/libs/components/src/lib/button/button.ts
+++ b/libs/components/src/lib/button/button.ts
@@ -11,7 +11,7 @@ import { AffixIconWithTrailing } from '../../shared/patterns/affix';
  *
  * @public
  */
-type ButtonConnotation = Extract<Connotation,
+export type ButtonConnotation = Extract<Connotation,
 | Connotation.Accent
 | Connotation.CTA
 | Connotation.Success
@@ -30,14 +30,14 @@ Appearance.Filled | Appearance.Outlined | Appearance.Ghost>;
  *
  * @public
  */
-type ButtonShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type ButtonShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Types of button size.
  *
  * @public
  */
-type ButtonSize = Extract<Size, Size.Condensed | Size.Normal | Size.Expanded>;
+export type ButtonSize = Extract<Size, Size.Condensed | Size.Normal | Size.Expanded>;
 
 /**
  * Base class for button

--- a/libs/components/src/lib/button/definition.ts
+++ b/libs/components/src/lib/button/definition.ts
@@ -9,6 +9,7 @@ import { Button } from './button';
 import styles from './button.scss';
 import { buttonTemplate as template } from './button.template';
 
+export type { ButtonAppearance, ButtonConnotation, ButtonShape, ButtonSize } from './button'
 
 /**
  *

--- a/libs/components/src/lib/calendar-event/calendar-event.ts
+++ b/libs/components/src/lib/calendar-event/calendar-event.ts
@@ -7,7 +7,7 @@ import type { Appearance, Connotation } from '../enums';
  *
  * @public
  */
-type CalendarEventConnotation = Extract<Connotation,
+export type CalendarEventConnotation = Extract<Connotation,
 | Connotation.Accent
 | Connotation.CTA
 | Connotation.Success
@@ -21,7 +21,7 @@ type CalendarEventConnotation = Extract<Connotation,
  *
  * @public
  */
-type CalendarEventAppearance = Extract<Appearance,
+export type CalendarEventAppearance = Extract<Appearance,
 Appearance.Filled | Appearance.Duotone | Appearance.Subtle>;
 
 /**

--- a/libs/components/src/lib/calendar-event/definition.ts
+++ b/libs/components/src/lib/calendar-event/definition.ts
@@ -5,6 +5,7 @@ import styles from './calendar-event.scss';
 import { CalendarEvent } from './calendar-event';
 import { CalendarEventTemplate as template } from './calendar-event.template';
 
+export type { CalendarEventAppearance, CalendarEventConnotation } from './calendar-event'
 
 /**
  * The calendar-event element is a custom element that is used to display a single event in a calendar.

--- a/libs/components/src/lib/combobox/combobox.ts
+++ b/libs/components/src/lib/combobox/combobox.ts
@@ -9,7 +9,7 @@ import { AffixIcon } from '../../shared/patterns';
  *
  * @public
  */
-type PopupPlacement = 'top' | 'bottom';
+export type PopupPlacement = 'top' | 'bottom';
 
 /**
  * Base class for combobox

--- a/libs/components/src/lib/combobox/definition.ts
+++ b/libs/components/src/lib/combobox/definition.ts
@@ -10,6 +10,7 @@ import styles from './combobox.scss';
 import { Combobox } from './combobox';
 import { comboboxTemplate as template } from './combobox.template';
 
+export type { PopupPlacement } from './combobox';
 
 /**
  * The combobox element.

--- a/libs/components/src/lib/components.ts
+++ b/libs/components/src/lib/components.ts
@@ -15,6 +15,7 @@ export * from './combobox/definition';
 export * from './elevation/definition';
 export * from './dialog/definition';
 export * from './divider/definition';
+export * from './data-grid/definition';
 export * from './fab/definition';
 export * from './header/definition';
 export * from './icon/definition';

--- a/libs/components/src/lib/dialog/definition.ts
+++ b/libs/components/src/lib/dialog/definition.ts
@@ -9,6 +9,7 @@ import styles from './dialog.scss';
 import { Dialog } from './dialog';
 import { DialogTemplate as template } from './dialog.template';
 
+export type { IconPlacement } from './dialog';
 
 /**
  * The dialog element.

--- a/libs/components/src/lib/dialog/dialog.ts
+++ b/libs/components/src/lib/dialog/dialog.ts
@@ -17,7 +17,7 @@ let dialogPolyfill: any;
  *
  * @public
  */
-type IconPlacement = 'top' | 'side';
+export type IconPlacement = 'top' | 'side';
 
 /**
  * Base class for dialog

--- a/libs/components/src/lib/fab/definition.ts
+++ b/libs/components/src/lib/fab/definition.ts
@@ -7,6 +7,7 @@ import styles from './fab.scss';
 import { Fab } from './fab';
 import { FabTemplate as template } from './fab.template';
 
+export type { FabConnotation, FABSize } from './fab';
 
 /**
  * The calendar-event element is a custom element that is used to display a single event in a calendar.

--- a/libs/components/src/lib/fab/fab.ts
+++ b/libs/components/src/lib/fab/fab.ts
@@ -16,7 +16,7 @@ export type FabConnotation = Extract<Connotation, Connotation.CTA | Connotation.
  *
  * @public
  */
-type FABSize = Extract<Size, Size.Normal | Size.Expanded>;
+export type FABSize = Extract<Size, Size.Normal | Size.Expanded>;
 
 /**
  * Base class for fab

--- a/libs/components/src/lib/focus/focus.ts
+++ b/libs/components/src/lib/focus/focus.ts
@@ -1,10 +1,10 @@
 import { FoundationElement } from '@microsoft/fast-foundation';
 
 /**
- * Base class for badge
+ * Base class for focus
  *
  * @public
  */
 export class Focus extends FoundationElement {
-	
+
 }

--- a/libs/components/src/lib/icon/definition.ts
+++ b/libs/components/src/lib/icon/definition.ts
@@ -4,6 +4,7 @@ import styles from './icon.scss';
 import { Icon } from './icon';
 import { iconTemplate as template } from './icon.template';
 
+export type { IconConnotation } from './icon'
 
 export const iconDefinition = Icon.compose<FoundationElementDefinition>({
 	baseName: 'icon',

--- a/libs/components/src/lib/icon/icon.ts
+++ b/libs/components/src/lib/icon/icon.ts
@@ -39,7 +39,7 @@ const resolveIcon = memoizeWith(identity as () => string, (iconId = '') => (icon
  *
  * @public
  */
-type IconConnotation = Extract<Connotation,
+export type IconConnotation = Extract<Connotation,
 | Connotation.Accent
 | Connotation.CTA
 | Connotation.Announcement

--- a/libs/components/src/lib/layout/definition.ts
+++ b/libs/components/src/lib/layout/definition.ts
@@ -4,6 +4,7 @@ import { Layout } from './layout';
 import styles from './layout.scss';
 import { layoutTemplate as template } from './layout.template';
 
+export type { AUTO_SIZING, ColumnBasis, ColumnSpacing, Gutters } from './layout';
 
 /**
  * Represents a layout custom element.

--- a/libs/components/src/lib/layout/layout.ts
+++ b/libs/components/src/lib/layout/layout.ts
@@ -4,9 +4,9 @@ import type { LayoutSize } from '../enums.js';
 
 
 export enum AUTO_SIZING { Fit = 'fit', Fill = 'fill' }
-type Gutters = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large>;
-type ColumnSpacing = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large>;
-type ColumnBasis = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large> | 'block';
+export type Gutters = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large>;
+export type ColumnSpacing = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large>;
+export type ColumnBasis = Extract<LayoutSize, LayoutSize.Small | LayoutSize.Medium | LayoutSize.Large> | 'block';
 
 /**
  * Base class for layout

--- a/libs/components/src/lib/listbox/definition.ts
+++ b/libs/components/src/lib/listbox/definition.ts
@@ -6,6 +6,7 @@ import { Listbox } from './listbox';
 import { ListboxTemplate as template } from './listbox.template';
 import styles from './listbox.scss';
 
+export type { LisboxAppearance } from './listbox';
 
 /**
  * The calendar-event element is a custom element that is used to display a single event in a calendar.

--- a/libs/components/src/lib/menu/definition.ts
+++ b/libs/components/src/lib/menu/definition.ts
@@ -5,6 +5,8 @@ import styles from './menu.scss';
 import { Menu } from './menu';
 import { MenuTemplate as template } from './menu.template';
 
+export type { Placement } from '@floating-ui/dom';
+
 /**
  * The menu element is a custom element that is used to display a list of menu items.
  */

--- a/libs/components/src/lib/note/definition.ts
+++ b/libs/components/src/lib/note/definition.ts
@@ -6,6 +6,7 @@ import styles from './note.scss';
 import { Note } from './note';
 import { NoteTemplate as template } from './note.template';
 
+export type { NoteConnotation } from './note';
 
 /**
  * The note element.

--- a/libs/components/src/lib/number-field/definition.ts
+++ b/libs/components/src/lib/number-field/definition.ts
@@ -6,6 +6,7 @@ import styles from './number-field.scss';
 import { NumberField } from './number-field';
 import { NumberFieldTemplate as template } from './number-field.template';
 
+export type { NumberFieldAppearance, NumberFieldShape } from './number-field';
 
 /**
  * The number-field element.

--- a/libs/components/src/lib/number-field/number-field.ts
+++ b/libs/components/src/lib/number-field/number-field.ts
@@ -4,8 +4,8 @@ import type {Appearance, Shape} from '../enums';
 import {FormElement, FormElementCharCount, FormElementHelperText, formElements, FormElementSuccessText} from '../../shared/patterns';
 import {AffixIcon} from '../../shared/patterns';
 
-type NumberFieldAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
-type NumberFieldShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type NumberFieldAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
+export type NumberFieldShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Base class for number-field

--- a/libs/components/src/lib/popup/definition.ts
+++ b/libs/components/src/lib/popup/definition.ts
@@ -6,6 +6,8 @@ import { Popup } from './popup';
 import styles from './popup.scss';
 import { popupTemplate as template } from './popup.template';
 
+export type { Popup } from './popup';
+export type { Strategy } from '@floating-ui/dom';
 
 /**
  * Represents a popup custom element.

--- a/libs/components/src/lib/progress-ring/definition.ts
+++ b/libs/components/src/lib/progress-ring/definition.ts
@@ -5,6 +5,8 @@ import styles from './progress-ring.scss';
 import {ProgressRing} from './progress-ring';
 import {ProgressRingTemplate as template} from './progress-ring.template';
 
+export type { ProgressRingConnotation } from './progress-ring';
+
 /**
  * The progress-ring element.
  */

--- a/libs/components/src/lib/progress/definition.ts
+++ b/libs/components/src/lib/progress/definition.ts
@@ -5,6 +5,8 @@ import styles from './progress.scss';
 import { Progress } from './progress';
 import { ProgressTemplate as template } from './progress.template';
 
+export type { ProgressConnotation, ProgressShape } from './progress';
+
 /**
  * The progress element.
  */

--- a/libs/components/src/lib/select/definition.ts
+++ b/libs/components/src/lib/select/definition.ts
@@ -9,6 +9,8 @@ import styles from './select.scss';
 import { Select } from './select';
 import { SelectTemplate as template } from './select.template';
 
+export type { SelectAppearance, SelectShape } from './select';
+
 /**
  * The select element.
  */

--- a/libs/components/src/lib/select/select.ts
+++ b/libs/components/src/lib/select/select.ts
@@ -6,8 +6,8 @@ import { AffixIcon } from '../../shared/patterns';
 import type { Appearance, Shape } from '../enums';
 
 
-type SelectAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
-type SelectShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type SelectAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
+export type SelectShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Base class for select

--- a/libs/components/src/lib/switch/definition.ts
+++ b/libs/components/src/lib/switch/definition.ts
@@ -6,6 +6,7 @@ import styles from './switch.scss';
 import { Switch } from './switch';
 import { SwitchTemplate as template } from './switch.template';
 
+export type { SwitchConnotation } from './switch';
 
 /**
  * The switch element.

--- a/libs/components/src/lib/text-area/definition.ts
+++ b/libs/components/src/lib/text-area/definition.ts
@@ -7,6 +7,7 @@ import styles from './text-area.scss';
 import { TextArea } from './text-area';
 import { TextAreaTemplate as template } from './text-area.template';
 
+export type { TextAreaWrap } from './text-area';
 
 /**
  * The text-area element.

--- a/libs/components/src/lib/text-area/text-area.ts
+++ b/libs/components/src/lib/text-area/text-area.ts
@@ -2,7 +2,7 @@ import { applyMixins, TextArea as FoundationElement } from '@microsoft/fast-foun
 import {attr} from '@microsoft/fast-element';
 import {FormElement, FormElementCharCount, FormElementHelperText, formElements, FormElementSuccessText} from '../../shared/patterns';
 
-type TextAreaWrap = 'hard' | 'soft' | 'off';
+export type TextAreaWrap = 'hard' | 'soft' | 'off';
 
 /**
  * Base class for text-area

--- a/libs/components/src/lib/text-field/definition.ts
+++ b/libs/components/src/lib/text-field/definition.ts
@@ -6,6 +6,7 @@ import { TextField } from './text-field';
 import styles from './text-field.scss';
 import { TextfieldTemplate as template } from './text-field.template';
 
+export type { TextFieldAppearance, TextFieldShape } from './text-field';
 
 /**
  * The text-field element.

--- a/libs/components/src/lib/text-field/text-field.ts
+++ b/libs/components/src/lib/text-field/text-field.ts
@@ -5,8 +5,8 @@ import {AffixIcon, FormElementCharCount, FormElementHelperText, FormElementSucce
 import {FormElement, formElements} from '../../shared/patterns';
 
 
-type TextFieldAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
-type TextFieldShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
+export type TextFieldAppearance = Extract<Appearance, Appearance.Outlined | Appearance.Ghost>;
+export type TextFieldShape = Extract<Shape, Shape.Rounded | Shape.Pill>;
 
 /**
  * Base class for text-field


### PR DESCRIPTION
Typescript constant types used/referenced in element properties/events/etc. types **must** be exported by the package to support consistency in the custom elements public contract. 

Those types needed to be referenced in the end user applications business code to make usage of Vivid components/elements fully typesafe and predictable during compile time.

It's always better to prevent potential bugs sooner than later 😃 

Additionally those types could be used to make fully sound typesafe https://github.com/Vonage/vivid-bindings-vue 
