### PR TITLE
fix(calendar): failing test on Windows (VIV-000)

### DIFF
--- a/libs/components/src/lib/calendar/calendar.spec.ts
+++ b/libs/components/src/lib/calendar/calendar.spec.ts
@@ -96,7 +96,7 @@ describe('vwc-calendar', () => {
 
 			const hour13th = element.shadowRoot?.querySelector('.row-headers > :nth-child(13)') as HTMLSpanElement;
 
-			const expectedTimeString = new Intl.DateTimeFormat('en-US', {hour: 'numeric', hour12: true})
+			const expectedTimeString = new Intl.DateTimeFormat(element.locales, {hour: 'numeric', hour12: true})
 				.format(new Date('2022-12-16T13:00:00.000'));
 
 			expect(hour13th.textContent?.trim()).toEqual(expectedTimeString);


### PR DESCRIPTION
meant to fix that for a while...

on Windows/Node 19:
`new Intl.DateTimeFormat('en-US', {hour: 'numeric', hour12: true}).format(new Date('2022-12-16T13:00:00.000'));`
is `1 PM`, but
`new Intl.DateTimeFormat(undefined, {hour: 'numeric', hour12: true}).format(new Date('2022-12-16T13:00:00.000'));`
is `1 pm`

which fails the "should display time in 12h format" test equality (that assumes the wrong default locale value).
