### PR TITLE
fix(tooltip): hide on Escape

### DIFF
--- a/libs/components/src/lib/tooltip/tooltip.spec.ts
+++ b/libs/components/src/lib/tooltip/tooltip.spec.ts
@@ -68,6 +68,25 @@ describe('vwc-tooltip', () => {
 		});
 	});
 
+	describe('escape', () => {
+		it('should disappear when Escape is pressed', async () => {
+			const anchor = await setAnchor();
+			element.anchor = 'anchor';
+			await elementUpdated(element);
+
+			fireEvent(anchor, new MouseEvent('mouseover'));
+			await elementUpdated(element);
+			expect(element.open)
+				.toEqual(true);
+
+			fireEvent(document, new KeyboardEvent('keydown', {key: 'Escape'}));
+			await elementUpdated(element);
+
+			expect(element.open)
+				.toEqual(false);
+		});
+	});
+
 	/**
 	 *
 	 */

--- a/libs/components/src/lib/tooltip/tooltip.ts
+++ b/libs/components/src/lib/tooltip/tooltip.ts
@@ -56,4 +56,17 @@ export class Tooltip extends Popup {
 	#hide = () => {
 		this.open = false;
 	};
+
+	_closeOnEscape = (e:KeyboardEvent) => {
+		if (e.key === 'Escape') this.#hide();
+	};
+	
+	override openChanged(_: boolean, newValue: boolean): void {
+		super.openChanged(_, newValue);
+		if (newValue) {
+			document.addEventListener('keydown', this._closeOnEscape);
+		} else {
+			document.removeEventListener('keydown', this._closeOnEscape);
+		}
+	}	
 }


### PR DESCRIPTION
see https://jira.vonage.com/browse/VIV-1017

making `closeOnEscape` private yields the TypeError `Cannot read private member from an object whose class did not declare it`, maybe an `override` bug? don't want to spend too much time investigating anyway.