### PR TITLE
feat(elevation): moving style to :before pseudo element (VIV-1098)

### DIFF
--- a/libs/components/src/lib/dialog/dialog.scss
+++ b/libs/components/src/lib/dialog/dialog.scss
@@ -10,7 +10,7 @@ $dialog-space-size: 24px;
 	box-sizing: border-box;
 	padding: 0;
 	border: none;
-	background: var(elevation.$vvd-elevation-fill);
+	background-color: transparent;
 	border-radius: 6px;
 	color: var(#{constants.$vvd-color-canvas-text});
 	max-block-size: var(#{variables.$dialog-max-block-size}, calc(100vh - 64px));
@@ -31,6 +31,9 @@ $dialog-space-size: 24px;
 	}
 
 	&.modal {
+		// reason for box-shadow & hardcoded color - PR-XXX
+
+		box-shadow: rgba(0, 0, 0, 0.4) 0px 4px 20px;
 		&::backdrop {
 			@include scrim-mixins.scrim-variables;
 		}
@@ -148,3 +151,4 @@ slot[name="main"] {
 	max-height: inherit;
 	border-radius: inherit;
 }
+

--- a/libs/components/src/lib/dialog/dialog.scss
+++ b/libs/components/src/lib/dialog/dialog.scss
@@ -31,7 +31,7 @@ $dialog-space-size: 24px;
 	}
 
 	&.modal {
-		// reason for box-shadow & hardcoded color - PR-XXX
+		// reason for box-shadow & hardcoded color - PR-1172
 
 		box-shadow: 0 4px 20px rgb(0 0 0 / 35%);
 		&::backdrop {

--- a/libs/components/src/lib/dialog/dialog.scss
+++ b/libs/components/src/lib/dialog/dialog.scss
@@ -33,7 +33,7 @@ $dialog-space-size: 24px;
 	&.modal {
 		// reason for box-shadow & hardcoded color - PR-XXX
 
-		box-shadow: rgba(0, 0, 0, 0.4) 0px 4px 20px;
+		box-shadow: 0 4px 20px rgb(0 0 0 / 35%);
 		&::backdrop {
 			@include scrim-mixins.scrim-variables;
 		}

--- a/libs/components/src/lib/elevation/elevation.scss
+++ b/libs/components/src/lib/elevation/elevation.scss
@@ -24,26 +24,27 @@ $dps: 0 2 4 8 12 16 24;
 			@include elevation.elevation($type);
 		}
 
-		&:before {
+		&::before {
 			$default: list.nth($dps, 2);
-			content: "";
+
 			position: absolute;
+			z-index: -1;
+			background: var(elevation.$vvd-elevation-fill);
+			block-size: 100%;
+			border-radius: inherit;
+			content: "";
+			filter: var(elevation.$vvd-elevation-shadow);
+			inline-size: 100%;
 			inset-block-start: 0;
 			inset-inline-start: 0;
-			inline-size: 100%;
-			block-size: 100%;
-			filter: var(elevation.$vvd-elevation-shadow);
-			background: var(elevation.$vvd-elevation-fill);
 			transition: background-color 0.15s linear, filter 0.15s linear;
-			border-radius: inherit;
-			z-index: -1;
 		}
 	}
 
 
 	&.no-shadow {
 		::slotted(*) {
-			&:before {
+			&::before {
 				filter: none;
 			}
 		}

--- a/libs/components/src/lib/elevation/elevation.scss
+++ b/libs/components/src/lib/elevation/elevation.scss
@@ -18,13 +18,34 @@ $dps: 0 2 4 8 12 16 24;
 	}
 
 	::slotted(*) {
-		background: var(elevation.$vvd-elevation-fill);
-		filter: var(elevation.$vvd-elevation-shadow);
-		transition: background-color 0.15s linear, filter 0.15s linear;
+		position: relative;
+
+		@include utils.spread-list-selectors(".dp", $dps, $default) using($type) {
+			@include elevation.elevation($type);
+		}
+
+		&:before {
+			$default: list.nth($dps, 2);
+			content: "";
+			position: absolute;
+			inset-block-start: 0;
+			inset-inline-start: 0;
+			inline-size: 100%;
+			block-size: 100%;
+			filter: var(elevation.$vvd-elevation-shadow);
+			background: var(elevation.$vvd-elevation-fill);
+			transition: background-color 0.15s linear, filter 0.15s linear;
+			border-radius: inherit;
+			z-index: -1;
+		}
 	}
+
+
 	&.no-shadow {
 		::slotted(*) {
-			filter: none;
+			&:before {
+				filter: none;
+			}
 		}
 	}
 }

--- a/libs/components/src/lib/elevation/elevation.scss
+++ b/libs/components/src/lib/elevation/elevation.scss
@@ -20,10 +20,6 @@ $dps: 0 2 4 8 12 16 24;
 	::slotted(*) {
 		position: relative;
 
-		@include utils.spread-list-selectors(".dp", $dps, $default) using($type) {
-			@include elevation.elevation($type);
-		}
-
 		&::before {
 			$default: list.nth($dps, 2);
 


### PR DESCRIPTION
Elevation adds background color and drop-down shadow filter and transition to its slotted item, causing component to change slotted items with position-fixed to be fixed to the new containing block (the component with elevation) and not the view-port.

In dialog showModal the filter is hidden by overflow-hidden therefor box-shadow was added.
The dialog box-shadow has hardcoded color and not variables because there's no need for color revert in darkmode.

