### PR TITLE
fix(11ty): add md files as watch targets (VIV-1105)

### DIFF
--- a/apps/docs/.eleventy.js
+++ b/apps/docs/.eleventy.js
@@ -25,6 +25,8 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addWatchTarget("dist/libs/components");
   eleventyConfig.addWatchTarget(`${ASSETS_DIR}/scripts`);
   eleventyConfig.addWatchTarget(`${ASSETS_DIR}/styles`);
+  eleventyConfig.addWatchTarget("docs");
+  eleventyConfig.addWatchTarget("libs/components/src/lib/*/README.md");
   eleventyConfig.setBrowserSyncConfig({
     server: {
       baseDir: OUTPUT_DIR


### PR DESCRIPTION
This will make 11ty reload when editing Markdown files in `docs` or component READMEs