### PR TITLE
fix(icons-gallery): add id array to the icons search (VIV-1139)

### DIFF
--- a/apps/docs/assets/scripts/icons-gallery.js
+++ b/apps/docs/assets/scripts/icons-gallery.js
@@ -81,6 +81,7 @@ function onClickFilter() {
 
 function filterIcons() {
   let iconsArray = jsonData.filter(item => item.keyword.some(icon => icon.includes(iconsTextField.value.toLowerCase())));
+  iconsArray = iconsArray.concat(jsonData.filter(item => item.id.includes(iconsTextField.value.toLowerCase())));
 
   iconsArray = filterIconsByTag(iconsArray);
   iconsShown > ICONS_TO_SHOW ? showMoreIcons(iconsArray) : showIcons(iconsArray);


### PR DESCRIPTION
e.g. searching for "chevron" doesn't return any results

