### PR TITLE
fix(tabs): prevent tab-panel blowout

### DIFF
--- a/libs/components/src/lib/tabs/tabs.scss
+++ b/libs/components/src/lib/tabs/tabs.scss
@@ -87,6 +87,9 @@
 }
 
 .tabpanel {
+	// this is for making overflow inside grid to work
+	min-inline-size: 0;
+
 	.base.orientation-vertical & {
 		block-size: 100%;
 		overflow-x: hidden;


### PR DESCRIPTION
since tab-panel is a grid child this issue is pretty common:
[Preventing a Grid Blowout](https://css-tricks.com/preventing-a-grid-blowout/)