### PR TITLE
fix(docs): underlying nav (VIV-000)

### DIFF
--- a/apps/docs/_includes/navigation.njk
+++ b/apps/docs/_includes/navigation.njk
@@ -10,7 +10,7 @@
             {% endfor %}
         </vwc-nav-disclosure>
         <vwc-nav-disclosure label="Design Tokens" {% if page.url.includes('/designs/') %} open {% endif %}>
-            {% for item in designs %}
+            {% for item in designs | publicPageFilter %}
                 <vwc-nav-item href="{{ ('/designs/' + item.title) | url }}" text="{{ item.title | replace("-", " ") | capitalize }}" {% if ('/designs/' + item.title + '/') == page.url %} aria-current="page" {% endif %}>
                     {% if (item.status) == "underlying" %}
                         <vwc-badge slot="meta" text="underlying" connotation="information" appearance="subtle" shape="pill"></vwc-badge>


### PR DESCRIPTION
<img width="330" alt="Screenshot 2023-07-13 at 14 07 47" src="https://github.com/Vonage/vivid-3/assets/10883919/60b6bbe1-337c-4ab8-b804-e5796c541ac8">


Everyone can see underlying nav