### PR TITLE
fix(docs): fix comment not being html comment (VIV-000)

### DIFF
--- a/apps/docs/code-example-preview/createCodeExample.js
+++ b/apps/docs/code-example-preview/createCodeExample.js
@@ -74,7 +74,7 @@ const renderiFrame = (
 			<details class="${CBD_DETAILS}" slot="main">
 				<summary></summary>
 				<div class="cbd-live-sample" data-index="${index}" role="region">
-					<pre>${_.escape("// Feel free to edit the code below. The live preview will update as you make changes.\n" + content)}</pre>
+					<pre>${_.escape("<!-- Feel free to edit the code below. The live preview will update as you make changes. -->\n" + content)}</pre>
 				</div>
 			</details>
 		</vwc-card>


### PR DESCRIPTION
When editing code this happens as the comment needs to be an html comment
<img width="881" alt="image" src="https://github.com/Vonage/vivid-3/assets/86777660/6b59fc6e-b017-4bb4-9a31-f57ad5a9362a">
