### PR TITLE
fix: fixes issue with keypress when not clickable

### DIFF
--- a/libs/components/src/lib/checkbox/checkbox.spec.ts
+++ b/libs/components/src/lib/checkbox/checkbox.spec.ts
@@ -267,8 +267,8 @@ describe('vwc-checkbox', () => {
 			expect(await axe(element)).toHaveNoViolations();
 		});
 
-		it('should not render a role attribute on the component element', async () => {
-			expect(element.getAttribute('role')).toBe(null);
+		it('should render role as presentation on the component element', async () => {
+			expect(element.getAttribute('role')).toBe('presentation');
 		});
 
 		it('should render the correct a11y attributes', async () => {
@@ -281,10 +281,6 @@ describe('vwc-checkbox', () => {
 			beforeEach(async () => {
 				element.ariaLabel = 'Label';
 				await elementUpdated(element);
-			});
-
-			it('should render role as presentation on the component element', async () => {
-				expect(element.getAttribute('role')).toBe('presentation');
 			});
 	
 			it('should render the correct a11y attributes', async () => {

--- a/libs/components/src/lib/checkbox/checkbox.template.ts
+++ b/libs/components/src/lib/checkbox/checkbox.template.ts
@@ -39,7 +39,7 @@ export const CheckboxTemplate: FoundationElementTemplate<ViewTemplate<Checkbox>,
 	const focusTemplate = focusTemplateFactory(context);
 	const iconTag = context.tagFor(Icon);
 
-	return html`<template role="${x => x.ariaLabel ? 'presentation' : null}">
+	return html`<template role="presentation">
 		<div class="${getClasses}"
 			role="checkbox"
 			aria-label="${x => x.ariaLabel}"
@@ -47,7 +47,7 @@ export const CheckboxTemplate: FoundationElementTemplate<ViewTemplate<Checkbox>,
 			aria-required="${x => x.required}"
 			aria-disabled="${x => x.disabled}"
 			aria-readonly="${x => x.readOnly}"
-			tabindex="${x => (x.disabled ? null : 0)}"
+			tabindex="${x => (x.tabindex || x.disabled ? null : 0)}"
 			@keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
 			@click="${(x, c) => x.clickHandler(c.event)}">
 			<div class="control">

--- a/libs/components/src/lib/checkbox/checkbox.ts
+++ b/libs/components/src/lib/checkbox/checkbox.ts
@@ -30,6 +30,7 @@ export type CheckboxConnotation = Extract<Connotation, | Connotation.Accent | Co
 @formElements
 export class Checkbox extends FoundationCheckbox {
 	@attr({attribute: 'aria-label'}) override ariaLabel: string | null = null;
+	@attr({attribute: 'tabindex'}) tabindex: string | null = null;
 	
 	/**
 	 * The connotation the checklist should have.

--- a/libs/components/src/lib/radio/radio.spec.ts
+++ b/libs/components/src/lib/radio/radio.spec.ts
@@ -128,24 +128,20 @@ describe('vwc-radio', () => {
 			expect(await axe(element)).toHaveNoViolations();
 		});
 
-		it('should not render a role attribute on the component element', async () => {
-			expect(element.getAttribute('role')).toBe(null);
-		});
-
 		it('should render the correct a11y attributes', async () => {
 			const baseElement = getBaseElement(element);
 
 			expect(baseElement?.getAttribute('role')).toBe('radio');
 		});
 
+		it('should render role as presentation on the component element', async () => {
+			expect(element.getAttribute('role')).toBe('presentation');
+		});
+
 		describe('aria-label', () => {
 			beforeEach(async () => {
 				element.ariaLabel = 'Label';
 				await elementUpdated(element);
-			});
-
-			it('should render role as presentation on the component element', async () => {
-				expect(element.getAttribute('role')).toBe('presentation');
 			});
 
 			it('should render the correct a11y attributes', async () => {

--- a/libs/components/src/lib/radio/radio.template.ts
+++ b/libs/components/src/lib/radio/radio.template.ts
@@ -24,7 +24,7 @@ const getClasses = ({ connotation, checked, readOnly, disabled }: Radio) => clas
 export const RadioTemplate: (context: ElementDefinitionContext) => ViewTemplate<Radio> = (context: ElementDefinitionContext) => {
 	const focusTemplate = focusTemplateFactory(context);
 
-	return html<Radio>`<template role="${x => x.ariaLabel ? 'presentation' : null}">
+	return html<Radio>`<template role="presentation">
 	<div class="${getClasses}"
 		role="radio"
 		aria-label="${x => x.ariaLabel}"

--- a/libs/components/src/lib/radio/radio.ts
+++ b/libs/components/src/lib/radio/radio.ts
@@ -18,6 +18,7 @@ export type RadioConnotation = Extract<Connotation,
  */
 export class Radio extends FastRadio {
 	@attr({attribute: 'aria-label'}) override ariaLabel: string | null = null;
+	
 	/**
 	 * Indicates the radio's label.
 	 *

--- a/libs/components/src/lib/selectable-box/README.md
+++ b/libs/components/src/lib/selectable-box/README.md
@@ -22,8 +22,8 @@ It accepts a subset of predefined values.
 
 ```html preview
 <vwc-layout gutters="small" row-spacing="small" column-basis="block">
-  <vwc-selectable-box connotation="accent" style="max-inline-size: 450px"> Accent box </vwc-selectable-box>
-  <vwc-selectable-box connotation="cta" style="max-inline-size: 450px"> CTA box </vwc-selectable-box>
+  <vwc-selectable-box connotation="accent" style="max-inline-size: 450px">Accent box</vwc-selectable-box>
+  <vwc-selectable-box connotation="cta" style="max-inline-size: 450px">CTA box</vwc-selectable-box>
 </vwc-layout>
 ```
 
@@ -38,8 +38,8 @@ When `control-type` is set to `radio`, it is the consuming app's responsibility 
 
 ```html preview
 <vwc-layout gutters="small" row-spacing="small" column-basis="block">
-  <vwc-selectable-box control-type="checkbox" style="max-inline-size: 450px"> Checkbox control </vwc-selectable-box>
-  <vwc-selectable-box control-type="radio" style="max-inline-size: 450px"> Radio control </vwc-selectable-box>
+  <vwc-selectable-box control-type="checkbox" style="max-inline-size: 450px">Checkbox control</vwc-selectable-box>
+  <vwc-selectable-box control-type="radio" style="max-inline-size: 450px">Radio control</vwc-selectable-box>
 </vwc-layout>
 ```
 
@@ -52,8 +52,8 @@ Set the `checked` attribute to indicate the checked state of the box.
 
 ```html preview
 <vwc-layout gutters="small" row-spacing="small" column-basis="block">
-  <vwc-selectable-box control-type="checkbox" checked style="max-inline-size: 450px"> Checked checkbox box </vwc-selectable-box>
-  <vwc-selectable-box control-type="radio" checked style="max-inline-size: 450px"> Checked radio box </vwc-selectable-box>
+  <vwc-selectable-box control-type="checkbox" checked style="max-inline-size: 450px">Checked checkbox box</vwc-selectable-box>
+  <vwc-selectable-box control-type="radio" checked style="max-inline-size: 450px">Checked radio box</vwc-selectable-box>
 </vwc-layout>
 ```
 
@@ -67,8 +67,8 @@ Setting the `clickable` attribute makes the whole card clickable, just make sure
 
 ```html preview
 <vwc-layout gutters="small" row-spacing="small" column-basis="block">
-  <vwc-selectable-box clickable style="max-inline-size: 450px"> Clickable accent box </vwc-selectable-box>
-  <vwc-selectable-box clickable connotation="cta" style="max-inline-size: 450px"> Clickable CTA box </vwc-selectable-box>
+  <vwc-selectable-box clickable style="max-inline-size: 450px">Clickable accent box</vwc-selectable-box>
+  <vwc-selectable-box clickable connotation="cta" style="max-inline-size: 450px">Clickable CTA box</vwc-selectable-box>
 </vwc-layout>
 ```
 
@@ -111,22 +111,9 @@ Use the `--selectable-box-spacing` variable to set the amount of spacing applied
 
 ## Accessibility
 
-To ensure the selectable box has an accessible label, it is neccessary to provide an `control-aria-label` attribute or associate a piece of content as a label using the `control-aria-labelledby` attribute, as in the examples below.
+To ensure the selectable box has an accessible label, it is neccessary to provide an `aria-label` attribute.
 
 Also, the boxes need a parent element to have a `role` attribute set to `group`.
-
-```html preview
-<vwc-layout role="group" gutters="small" row-spacing="small" column-basis="block">
-  <vwc-selectable-box control-aria-label="Box 1" style="max-inline-size: 450px">
-    <div>Use the control-aria-label attribute to make the box accessible.</div>
-  </vwc-selectable-box>
-
-  <vwc-selectable-box control-aria-labelledby="box2-heading" style="max-inline-size: 450px">
-    <h3 id="box2-heading">Accessible selectable box</h3>
-    <p>Use the control-aria-labelledby attribute to make the box accessible.</p>
-  </vwc-selectable-box>
-</vwc-layout>
-```
 
 ## Use cases
 

--- a/libs/components/src/lib/selectable-box/selectable-box.spec.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.spec.ts
@@ -24,12 +24,14 @@ describe('vwc-selectable-box', () => {
 				FoundationElementRegistry
 			);
 			expect(element).toBeInstanceOf(SelectableBox);
-			expect(element.controlAriaLabel).toBe(null);
-			expect(element.controlAriaLabelledby).toBe(null);
 			expect(element.controlType).toBe(undefined);
 			expect(element.connotation).toBe(undefined);
 			expect(element.tight).toBe(false);
 			expect(element.checked).toBe(false);
+		});
+
+		it('should render the role attribute set to "presentation"', async () => {
+			expect(element.getAttribute('role')).toBe('presentation');
 		});
 	});
 
@@ -154,6 +156,22 @@ describe('vwc-selectable-box', () => {
 			expect(element.checked).toBe(true);
 		});
 
+		describe('keyboard (not clickable)', () => {
+			it('should not emit the change event with Space keypress', async () => {
+				baseElement.dispatchEvent(new KeyboardEvent('keydown', { composed: true, code: 'Space' }));
+				
+				expect(spy).not.toHaveBeenCalled();
+				expect(element.checked).toBe(false);
+			});
+
+			it('should not emit the change event with Enter keypress', async () => {
+				baseElement.dispatchEvent(new KeyboardEvent('keydown', { composed: true, code: 'Enter' }));
+				
+				expect(spy).not.toHaveBeenCalled();
+				expect(element.checked).toBe(false);
+			});
+		});
+
 		describe('radio', () => {
 			it('should emit the change event when the control element changes', async () => {
 				element.controlType = 'radio';
@@ -204,15 +222,25 @@ describe('vwc-selectable-box', () => {
 					expect(spy).toHaveBeenCalled();
 					expect(element.checked).toBe(true);
 				});
+
+				it('should not emit the change event another key is pressed', async () => {
+					baseElement.dispatchEvent(new KeyboardEvent('keydown', { composed: true, code: '65' }));
+					
+					expect(spy).not.toHaveBeenCalled();
+					expect(element.checked).toBe(false);
+				});
 			});
 		});
 	});
 
 	describe('a11y', () => {
 		beforeEach(async () => {
-			element.controlAriaLabel = 'Box 1';
-			element.controlAriaLabelledby = 'heading1';
+			element.ariaLabel = 'Box 1';
 			await elementUpdated(element);
+		});
+
+		it('should pass html a11y test', async () => {
+			expect(await axe(element)).toHaveNoViolations();
 		});
 
 		it('should put the correct a11y attributes on the control element', async () => {
@@ -220,10 +248,13 @@ describe('vwc-selectable-box', () => {
 			
 			expect(control?.getAttribute('tabindex')).toBe('0');
 			expect(control?.getAttribute('aria-label')).toBe('Box 1');
-			expect(control?.getAttribute('aria-labelledby')).toBe('heading1');
 		});
 
 		describe('radio', () => {
+			it('should pass html a11y test', async () => {
+				expect(await axe(element)).toHaveNoViolations();
+			});
+
 			it('should put the correct a11y attributes on the control element', async () => {
 				element.controlType = 'radio';
 				await elementUpdated(element);
@@ -232,7 +263,6 @@ describe('vwc-selectable-box', () => {
 
 				expect(control?.getAttribute('tabindex')).toBe('0');
 				expect(control?.getAttribute('aria-label')).toBe('Box 1');
-				expect(control?.getAttribute('aria-labelledby')).toBe('heading1');
 			});
 		});
 
@@ -249,6 +279,24 @@ describe('vwc-selectable-box', () => {
 				expect(control?.getAttribute('aria-hidden')).toBe('true');
 			});
 
+			it('should put the correct a11y attributes on the base element', async () => {
+				expect(baseElement?.getAttribute('aria-label')).toBe('Box 1');
+				expect(baseElement?.getAttribute('aria-pressed')).toBe(null);
+				expect(baseElement?.getAttribute('role')).toBe('button');
+				expect(baseElement?.getAttribute('tabindex')).toBe('0');
+			});
+
+			it('should add the aria-pressed attribute to the base element when checked is true', async () => {
+				element.checked = true;
+				await elementUpdated(element);
+				
+				expect(baseElement?.getAttribute('aria-pressed')).toBe('true');
+			});
+
+			it('should pass html a11y test', async () => {
+				expect(await axe(element)).toHaveNoViolations();
+			});
+
 			describe('radio', () => {
 				it('should put the correct a11y attributes on the control element', async () => {
 					element.controlType = 'radio';
@@ -258,33 +306,10 @@ describe('vwc-selectable-box', () => {
 					expect(control?.getAttribute('tabindex')).toBe('-1');
 					expect(control?.getAttribute('aria-hidden')).toBe('true');
 				});
-			});
 
-			it('should put the correct a11y attributes on the base element', async () => {
-				expect(baseElement?.getAttribute('aria-label')).toBe('Box 1');
-				expect(baseElement?.getAttribute('aria-labelledby')).toBe('heading1');
-				expect(baseElement?.getAttribute('aria-pressed')).toBe(null);
-				expect(baseElement?.getAttribute('role')).toBe('button');
-				expect(baseElement?.getAttribute('tabindex')).toBe('0');
-			});
-
-			it('should add the aria-checked attribute to the base element when checked is true', async () => {
-				element.checked = true;
-				await elementUpdated(element);
-				
-				expect(baseElement?.getAttribute('aria-pressed')).toBe('true');
-			});
-		});
-
-		/* these are skipped until aria-label and aria-labelledby 
-		   can be passed down the checkbox's control element */
-		it('should pass html a11y test', async () => {
-			expect(await axe(element)).toHaveNoViolations();
-		});
-
-		describe('clickable', () => {
-			it('should pass html a11y test', async () => {
-				expect(await axe(element)).toHaveNoViolations();
+				it('should pass html a11y test', async () => {
+					expect(await axe(element)).toHaveNoViolations();
+				});
 			});
 		});
 	});

--- a/libs/components/src/lib/selectable-box/selectable-box.template.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.template.ts
@@ -29,8 +29,7 @@ function checkbox(context: ElementDefinitionContext) {
 	
 	return html<SelectableBox>`${when(x => x.controlType !== 'radio', html`
 		<${checkboxTag}
-			aria-label="${x => !x.clickable && x.controlAriaLabel ? x.controlAriaLabel : null}"
-			aria-labelledby="${x => !x.clickable && x.controlAriaLabelledby ? x.controlAriaLabelledby : null}"
+			aria-label="${x => !x.clickable && x.ariaLabel ? x.ariaLabel : null}"
 			tabindex="${x => x.clickable ? '-1' : '0'}"
 			aria-hidden="${x => x.clickable}"
 			@change="${x => handleControlChange(x)}"
@@ -46,8 +45,7 @@ function radio(context: ElementDefinitionContext) {
 
 	return html<SelectableBox>`${when(x => x.controlType === 'radio', html`
 		<${radioTag}
-			aria-label="${x => !x.clickable && x.controlAriaLabel ? x.controlAriaLabel : null}"
-			aria-labelledby="${x => !x.clickable && x.controlAriaLabelledby ? x.controlAriaLabelledby : ''}"
+			aria-label="${x => !x.clickable && x.ariaLabel ? x.ariaLabel : null}"
 			tabindex="${x => x.clickable ? '-1' : '0'}"
 			aria-hidden="${x => x.clickable}"
 			@change="${x => handleControlChange(x)}"
@@ -71,14 +69,13 @@ export const SelectableBoxTemplate: (
 	context: ElementDefinitionContext
 ) => {
 	const focusTemplate = focusTemplateFactory(context);
-	return html<SelectableBox>`
+	return html<SelectableBox>`<template role="presentation">
 	<div
 		class="${getClasses}"
 		tabindex="${x => x.clickable ? '0' : null}"
 		role="${x => x.clickable ? 'button' : null}"
 		aria-pressed="${x => x.clickable && x.checked ? x.checked : null}"
-		aria-label="${x => x.clickable ? x.controlAriaLabel : null}"
-		aria-labelledby="${x => x.clickable ? x.controlAriaLabelledby : null}"
+		aria-label="${x => x.clickable ? x.ariaLabel : null}"
 		@keydown="${(x, c) => x._handleKeydown(c.event as KeyboardEvent)}"
 		@click="${x => x.clickable ? x._handleCheckedChange() : null}"
 	>
@@ -87,5 +84,5 @@ export const SelectableBoxTemplate: (
 		${radio(context)}
 		<slot></slot>
 	</div>
-`;
+<//template>`;
 };

--- a/libs/components/src/lib/selectable-box/selectable-box.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.ts
@@ -25,6 +25,8 @@ export type SelectableBoxControlType = 'checkbox' | 'radio';
  * @event change - Fired when the checked state changes
  */
 export class SelectableBox extends FoundationElement {
+	@attr({attribute: 'aria-label'}) override ariaLabel: string | null = null;
+
 	/**
 	* Controls the checked state of the box
 	*
@@ -49,24 +51,6 @@ export class SelectableBox extends FoundationElement {
 	 * HTML Attribute: connotation
 	 */
 	@attr connotation?: SelectableBoxConnotation;
-
-	/**
-	 * Adds an accessible label to selectable box
-	 *
-	 * @public
-	 * @remarks
-	 * HTML Attribute: control-aria-label
-	 */
-	@attr({ attribute: 'control-aria-label' }) controlAriaLabel: string | null = null;
-
-	/**
-	 * Links a piece of content as an accessible label
-	 *
-	 * @public
-	 * @remarks
-	 * HTML Attribute: control-aria-labelledby
-	 */
-	@attr({ attribute: 'control-aria-labelledby' }) controlAriaLabelledby: string | null = null;
 
 	/**
 	 * The type of control the box should have: checkbox or radio.
@@ -98,8 +82,9 @@ export class SelectableBox extends FoundationElement {
 	 * @internal
 	 */
 	_handleKeydown(event: KeyboardEvent) {
+		if (!this.clickable) return true;
 		if (event.code === 'Space' || event.code === 'Enter' && this.clickable) 
-			this._handleCheckedChange();
+			return this._handleCheckedChange();
 		return true;
 	}
 }


### PR DESCRIPTION
- Fixes a bug with keypress when box is not clickable
- Fixes a11y issue with checkbox when box is clickable
- Follows the same method for `aria-label` as other components and removes `aria-labelledby`