### PR TITLE
fix(side-drawer): add block-size to content (VIV-1352)

### DIFF
--- a/libs/components/src/lib/side-drawer/README.md
+++ b/libs/components/src/lib/side-drawer/README.md
@@ -260,3 +260,21 @@ Select `base` part to access the component's internal *base* element (which repr
   }
 </script>
 ```
+
+### Full content height
+```html preview full
+<style>
+.side-drawer {
+	block-size: 100vh;
+	background-color: var(--vvd-color-information-50);
+}
+</style>
+<vwc-side-drawer class="side-drawer" open>
+	<vwc-layout gutters="small">
+			Side Drawer content
+  </vwc-layout>  <vwc-layout gutters="small-inline" slot="app-content">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore  eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+ </vwc-layout>
+
+</vwc-side-drawer>
+```

--- a/libs/components/src/lib/side-drawer/side-drawer.scss
+++ b/libs/components/src/lib/side-drawer/side-drawer.scss
@@ -4,6 +4,9 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../shared/src/lib/sass/mixins/scrim" as scrim-mixins;
 
+:host {
+	display: block;
+}
 
 $inline-size: 280px;
 
@@ -35,6 +38,10 @@ $inline-size: 280px;
 		}
 	}
 
+	.side-drawer-app-content {
+		block-size: 100%;
+	}
+
 	&.open:not(.modal) {
 		&.trailing + {
 			.side-drawer-app-content {
@@ -53,6 +60,7 @@ $inline-size: 280px;
 		transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 }
+
 
 .scrim {
 	@include scrim-mixins.scrim-variables;


### PR DESCRIPTION
add the div that wraps the content slot (with the class .side-drawer-app-content) style of block-size:100%
**pros:**
if the host - the div's parent gets a height the div gets its parent full height
if no height is set - the block-size has no effect - doesn't change design or behaviour.
if being used - only adding block-size + display block on host is needed
**cons -** the change will effect only the height. (though the issue is regarding only the height so its not really a con).


another option that was on the table was to export the div that wraps the content slot (with the class .side-drawer-app-content) as part.
**pros -** any style can be set on it.
**cons -**
- the div has custom inline-margin that align with the side-drawer width and if changed - will be a problem with the side-drawer design and behaviur.
- users will need to add css for the part and for the host
