### PR TITLE
chore(components): use border radius variables (VIV-1461)

### DIFF
--- a/libs/components/src/lib/action-group/action-group.scss
+++ b/libs/components/src/lib/action-group/action-group.scss
@@ -10,6 +10,7 @@
 	$default: fieldset,
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 :host {
@@ -46,11 +47,11 @@
 
 /* Shape */
 .base:not(.shape-pill) {
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 }
 
 .base.shape-pill {
-	border-radius: 24px;
+	border-radius: #{border-radius-variables.$border-radius-extra-expanded};
 }
 
 /* Separator */

--- a/libs/components/src/lib/alert/alert.scss
+++ b/libs/components/src/lib/alert/alert.scss
@@ -1,4 +1,5 @@
 @use "partials/variables" as variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 
@@ -20,7 +21,7 @@ $alert-transition-delay: --transition-delay;
 .control {
 	position: fixed;
 	z-index: 10;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	inline-size: max-content;
 
 	// placement
@@ -73,7 +74,7 @@ $alert-transition-delay: --transition-delay;
 	align-items: center;
 	padding: 16px;
 	background-color: var(--vvd-color-neutral-50);
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	color: var(#{constants.$vvd-color-canvas-text});
 	column-gap: 16px;
 

--- a/libs/components/src/lib/appearance-ui/appearance-ui.scss
+++ b/libs/components/src/lib/appearance-ui/appearance-ui.scss
@@ -1,4 +1,5 @@
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent cta success alert warning information announcement,
@@ -29,7 +30,7 @@
 	justify-content: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
 	block-size: 40px;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	padding-inline: 16px;

--- a/libs/components/src/lib/avatar/avatar.scss
+++ b/libs/components/src/lib/avatar/avatar.scss
@@ -16,6 +16,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 .base {
@@ -46,11 +47,11 @@
 	}
 
 	&:not(.shape-pill) {
-		border-radius: 6px;
+		border-radius: #{border-radius-variables.$border-radius-normal};
 	}
 
 	&.shape-pill {
-		border-radius: 50%;
+		border-radius: #{border-radius-variables.$border-radius-full};
 	}
 
 	.initials {

--- a/libs/components/src/lib/badge/badge.scss
+++ b/libs/components/src/lib/badge/badge.scss
@@ -15,6 +15,8 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
+
 
 :host {
 	display: inline-block;
@@ -68,10 +70,10 @@
 /* Shape */
 
 .base:not(.shape-pill) {
-	border-radius: 4px;
+	border-radius: #{border-radius-variables.$border-radius-semi-condensed};
 }
 .base.shape-pill {
-	border-radius: 14px;
+	border-radius: #{border-radius-variables.$border-radius-expanded};
 }
 
 /* Icon */

--- a/libs/components/src/lib/breadcrumb-item/breadcrumb-item.scss
+++ b/libs/components/src/lib/breadcrumb-item/breadcrumb-item.scss
@@ -1,5 +1,6 @@
 @use "../../../../shared/src/lib/sass/utils" as utils;
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 .base {
 	display: flex;
@@ -38,7 +39,7 @@
 	--focus-inset: -4px -8px;
 	--focus-stroke-gap-color: transparent;
 
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	.control:not(:focus-visible)>& {
 		display: none;
 	}

--- a/libs/components/src/lib/button/button.scss
+++ b/libs/components/src/lib/button/button.scss
@@ -2,6 +2,7 @@
 @use "partials/variables" as variables;
 @use "partials/mixins" as mixins;
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent cta success alert,
@@ -90,20 +91,20 @@
 
 	/* Shape */
 	&:not(.shape-pill) {
-		border-radius: 6px;
+		border-radius: #{border-radius-variables.$border-radius-normal};
 	}
 
 	&.shape-pill {
 		&:not(.icon-only, .stacked) {
-			border-radius: 24px;
+			border-radius: #{border-radius-variables.$border-radius-extra-expanded};
 		}
 
 		&.stacked {
-			border-radius: 24px;
+			border-radius: #{border-radius-variables.$border-radius-extra-expanded};
 		}
 
 		&.icon-only {
-			border-radius: 50%;
+			border-radius: #{border-radius-variables.$border-radius-full};
 		}
 	}
 

--- a/libs/components/src/lib/calendar-event/calendar-event.scss
+++ b/libs/components/src/lib/calendar-event/calendar-event.scss
@@ -1,4 +1,5 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "partials/variables" as variables;
 @use "../calendar/partials/variables" as calendar-variables;
@@ -52,7 +53,7 @@
 	padding: $gutter $gutter * 2;
 	background-color: var(#{appearance.get-appearance-token(fill)});
 	block-size: calc(var(#{variables.$duration}, 1) * #{$hour-block-size} + #{$dividers-block-size} - #{$margin-block * 2});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	inline-size: calc(100% - #{$unit-indent} - #{$indent-calc});

--- a/libs/components/src/lib/calendar/calendar.scss
+++ b/libs/components/src/lib/calendar/calendar.scss
@@ -1,6 +1,7 @@
 @use "partials/variables" as variables;
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 ol {
@@ -50,7 +51,7 @@ ol {
 	display: grid;
 	overflow: hidden;
 	background: var(#{constants.$vvd-color-surface-2dp});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	counter-reset: listing;
 	filter: var(#{constants.$vvd-shadow-surface-2dp});
 	gap: variables.$gap;

--- a/libs/components/src/lib/card/card.scss
+++ b/libs/components/src/lib/card/card.scss
@@ -1,15 +1,15 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "partials/card-variables" as card-variables;
-
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 :host {
 	display: flex;
 }
 
 .base {
-	border-radius: 6px;
 	inline-size: 100%;
 	text-align: start;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 }
 
 .wrapper {

--- a/libs/components/src/lib/card/card.scss
+++ b/libs/components/src/lib/card/card.scss
@@ -7,9 +7,9 @@
 }
 
 .base {
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	inline-size: 100%;
 	text-align: start;
-	border-radius: #{border-radius-variables.$border-radius-normal};
 }
 
 .wrapper {

--- a/libs/components/src/lib/checkbox/checkbox.scss
+++ b/libs/components/src/lib/checkbox/checkbox.scss
@@ -15,6 +15,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 $low-ink-color: --_low-ink-color;
 $size: #{size.$vvd-size-ultra-condensed};
@@ -104,7 +105,7 @@ label {
 	#{focus-variables.$focus-inset}: -3px;
 	#{focus-variables.$focus-stroke-gap-color}: transparent;
 
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 
 	.base:not(:focus-visible) & {
 		display: none;

--- a/libs/components/src/lib/combobox/combobox.scss
+++ b/libs/components/src/lib/combobox/combobox.scss
@@ -1,5 +1,6 @@
 @use "../focus/partials/variables" as focus-variables;
 @use "../popup/partials/variables" as popup-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent,
 	$shades: backdrop intermediate primary soft,
@@ -42,7 +43,7 @@
 
 	padding: 4px;
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	contain: paint;
 }

--- a/libs/components/src/lib/dialog/dialog.scss
+++ b/libs/components/src/lib/dialog/dialog.scss
@@ -3,6 +3,7 @@
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
 @use "../../../../shared/src/lib/sass/mixins/scrim" as scrim-mixins;
 @use "../../../../shared/src/lib/sass/mixins/elevation" as elevation;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 $dialog-space-size: 24px;
 
@@ -11,7 +12,7 @@ $dialog-space-size: 24px;
 	padding: 0;
 	border: none;
 	background-color: transparent;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	color: var(#{constants.$vvd-color-canvas-text});
 	max-block-size: var(#{variables.$dialog-max-block-size}, calc(100vh - 64px));
 	max-inline-size: var(#{variables.$dialog-max-inline-size}, var(#{variables.$dialog-default-max-inline-size}));

--- a/libs/components/src/lib/empty-state/empty-state.scss
+++ b/libs/components/src/lib/empty-state/empty-state.scss
@@ -1,4 +1,6 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
+
 
 :host {
 	display: block;
@@ -20,7 +22,7 @@
 	justify-content: center;
 	background-color: var(#{constants.$vvd-color-neutral-100});
 	block-size: 120px;
-	border-radius: 50%;
+	border-radius: #{border-radius-variables.$border-radius-full};
 	inline-size: 120px;
 }
 

--- a/libs/components/src/lib/fab/fab.scss
+++ b/libs/components/src/lib/fab/fab.scss
@@ -17,6 +17,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 .control {
@@ -60,7 +61,7 @@
 	}
 
 	&.icon-only {
-		border-radius: 50%;
+		border-radius: #{border-radius-variables.$border-radius-full};
 		padding-inline: 0;
 		place-content: center;
 

--- a/libs/components/src/lib/fab/fab.scss
+++ b/libs/components/src/lib/fab/fab.scss
@@ -56,7 +56,7 @@
 	}
 
 	&:not(.size-expanded) {
-		#{variables.$border-radius}: 24px;
+		#{variables.$border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 		#{variables.$block-size}: #{size.$vvd-size-normal};
 	}
 

--- a/libs/components/src/lib/file-picker/file-picker.scss
+++ b/libs/components/src/lib/file-picker/file-picker.scss
@@ -1,5 +1,6 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 $low-ink-color: --_low-ink-color;
 
@@ -30,7 +31,7 @@ $low-ink-color: --_low-ink-color;
 	padding: 16px;
 	border: 1px dashed var(#{constants.$vvd-color-neutral-400});
 	background-color: var(#{constants.$vvd-color-cta-50});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	color: var(#{constants.$vvd-color-neutral-600});
 	cursor: pointer;
 	font: var(#{constants.$vvd-typography-base});
@@ -54,7 +55,7 @@ $low-ink-color: --_low-ink-color;
 	display: grid;
 	box-sizing: border-box;
 	padding: 6px 12px;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	grid-template-columns: 1fr auto;
 	grid-template-rows: auto auto;
 	inline-size: 100%;

--- a/libs/components/src/lib/listbox/listbox.scss
+++ b/libs/components/src/lib/listbox/listbox.scss
@@ -13,6 +13,7 @@
 	$default: fieldset
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 :host {
 	display: inline-block;
@@ -57,11 +58,11 @@
 
 /* Shape */
 .base:not(.shape-pill) {
-	#{variables.$listbox-border-radius}: 6px;
+	#{variables.$listbox-border-radius}: #{border-radius-variables.$border-radius-normal};
 }
 
 .base.shape-pill {
-	#{variables.$listbox-border-radius}: 24px;
+	#{variables.$listbox-border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 }
 
 ::slotted([role="option"]) {

--- a/libs/components/src/lib/menu-item/menu-item.scss
+++ b/libs/components/src/lib/menu-item/menu-item.scss
@@ -15,6 +15,7 @@
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
 @use "partials/menu-item-variables" as menu-item-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 @supports selector(:focus-visible) {
@@ -64,7 +65,7 @@
 }
 
 .focus-indicator {
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	:host(:not(:focus-visible)) & {
 		display: none;
 	}

--- a/libs/components/src/lib/menu/menu.scss
+++ b/libs/components/src/lib/menu/menu.scss
@@ -1,5 +1,6 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "partials/variables" as variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 .base {
 	display: flex;
@@ -22,7 +23,7 @@
 
 ::slotted(a[role="menuitem"]:focus) {
 	display: block;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 3px currentColor;
 	outline: 2px solid currentColor;
 	outline-offset: -2px;

--- a/libs/components/src/lib/nav-disclosure/nav-disclosure.scss
+++ b/libs/components/src/lib/nav-disclosure/nav-disclosure.scss
@@ -15,6 +15,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 .control {
@@ -27,7 +28,7 @@
 	box-sizing: border-box;
 	align-items: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	cursor: pointer;

--- a/libs/components/src/lib/nav-item/nav-item.scss
+++ b/libs/components/src/lib/nav-item/nav-item.scss
@@ -1,5 +1,6 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent,
@@ -27,7 +28,7 @@
 	box-sizing: border-box;
 	align-items: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	font: var(#{constants.$vvd-typography-base});

--- a/libs/components/src/lib/note/note.scss
+++ b/libs/components/src/lib/note/note.scss
@@ -13,6 +13,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 .base {
@@ -23,7 +24,7 @@
 	align-items: flex-start;
 	padding: #{size.$vvd-size-ultra-condensed};
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(--vvd-color-canvas-text);
 	column-gap: 16px;

--- a/libs/components/src/lib/option/option.scss
+++ b/libs/components/src/lib/option/option.scss
@@ -16,6 +16,7 @@
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
 @use "../listbox/partials/variables" as listbox-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 :host([disabled]) {
 	cursor: not-allowed;
@@ -34,7 +35,7 @@
 	box-sizing: border-box;
 	align-items: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{listbox-variables.$option-appearance-color-text}, var(#{appearance.get-appearance-token(text)}));
 	font: var(#{constants.$vvd-typography-base});

--- a/libs/components/src/lib/pagination/pagination.scss
+++ b/libs/components/src/lib/pagination/pagination.scss
@@ -1,15 +1,16 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 .control {
 	display: inline-flex;
 	justify-content: space-between;
 
 	&:not(.shape-pill) {
-		border-radius: 4px;
+		border-radius: #{border-radius-variables.$border-radius-semi-condensed};
 	}
 	&.shape-pill {
-		border-radius: 14px;
+		border-radius: #{border-radius-variables.$border-radius-expanded};
 	}
 }
 

--- a/libs/components/src/lib/popup/popup.scss
+++ b/libs/components/src/lib/popup/popup.scss
@@ -1,5 +1,6 @@
 @use "partials/variables" as variables;
 @use "../../../../shared/src/lib/sass/utils" as utils;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 .control {
 	background: var(#{utils.get-color-token(surface-4dp)});
@@ -14,7 +15,7 @@
 
 .popup-wrapper {
 	z-index: 10;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	inline-size: fit-content;
 
 	&:not(.absolute) {

--- a/libs/components/src/lib/radio/radio.scss
+++ b/libs/components/src/lib/radio/radio.scss
@@ -16,6 +16,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 $control-size: #{size.$vvd-size-ultra-condensed};
@@ -53,7 +54,7 @@ $control-border: 2px;
 	position: relative;
 	flex-shrink: 0;
 	block-size: $control-size;
-	border-radius: 50%;
+	border-radius: #{border-radius-variables.$border-radius-full};
 	box-shadow: inset 0 0 0 $control-border var(#{appearance.get-appearance-token(outline)});
 	inline-size: $control-size;
 
@@ -86,7 +87,7 @@ label {
 	#{focus-variables.$focus-inset}: -3px;
 	#{focus-variables.$focus-stroke-gap-color}: transparent;
 
-	border-radius: 50%;
+	border-radius: #{border-radius-variables.$border-radius-full};
 
 	:host(:not(:focus-visible)) & {
 		display: none;

--- a/libs/components/src/lib/select/select.scss
+++ b/libs/components/src/lib/select/select.scss
@@ -14,6 +14,7 @@
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
 @use "../focus/partials/variables" as focus-variables;
 @use "partials/variables" as variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 $low-ink-color: --_low-ink-color;
 
@@ -71,11 +72,11 @@ $low-ink-color: --_low-ink-color;
 	}
 
 	&:not(.shape-pill) {
-		#{variables.$select-control-border-radius}: 6px;
+		#{variables.$select-control-border-radius}: #{border-radius-variables.$border-radius-normal};
 	}
 
 	&.shape-pill {
-		#{variables.$select-control-border-radius}: 24px;
+		#{variables.$select-control-border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 	}
 }
 
@@ -139,6 +140,6 @@ $low-ink-color: --_low-ink-color;
 	}
 
 	:host([multiple]) & {
-		#{variables.$select-control-border-radius}: 6px;
+		#{variables.$select-control-border-radius}: #{border-radius-variables.$border-radius-normal};
 	}
 }

--- a/libs/components/src/lib/selectable-box/selectable-box.scss
+++ b/libs/components/src/lib/selectable-box/selectable-box.scss
@@ -1,5 +1,6 @@
 @use "../focus/partials/variables" as focus-variables;
 @use "partials/variables" as variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/utils" as utils;
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
@@ -34,7 +35,7 @@
 	padding: var(#{variables.$spacing-var}, 16px);
 	border: 1px solid var(#{appearance.get-appearance-token(outline)});
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	inline-size: 100%;
 	padding-block-start: calc(var(#{variables.$spacing-var}, 16px) + 36px);
 	text-align: start;

--- a/libs/components/src/lib/slider/slider.scss
+++ b/libs/components/src/lib/slider/slider.scss
@@ -12,6 +12,8 @@
 	$default: filled
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
+
 
 $track-thickness: 2px;
 
@@ -54,14 +56,14 @@ $track-thickness: 2px;
 	.track {
 		position: absolute;
 		background: var(#{variables.$track-background-color});
-		border-radius: 4px;
+		border-radius: #{border-radius-variables.$border-radius-semi-condensed};
 
 		.track-start {
 			position: absolute;
 			left: 0;
 			height: 100%;
 			background: var(#{variables.$track-start-background-color});
-			border-radius: 4px;
+			border-radius: #{border-radius-variables.$border-radius-semi-condensed};
 		}
 	}
 
@@ -78,7 +80,7 @@ $track-thickness: 2px;
 			width: var(#{variables.$thumb-interaction-indicator-size});
 			height: var(#{variables.$thumb-interaction-indicator-size});
 			background-color: var(#{variables.$track-start-background-color});
-			border-radius: 50%;
+			border-radius: #{border-radius-variables.$border-radius-full};
 			content: "";
 			opacity: var(#{variables.$thumb-interaction-indicator-alpha}, 0);
 			transition: opacity 0.2s ease-out 0s;
@@ -90,7 +92,7 @@ $track-thickness: 2px;
 			width: var(#{variables.$thumb-size});
 			height: var(#{variables.$thumb-size});
 			background-color: var(#{variables.$track-start-background-color});
-			border-radius: 50%;
+			border-radius: #{border-radius-variables.$border-radius-full};
 			content: "";
 			inset: calc((var(#{variables.$thumb-interaction-indicator-size}) - var(#{variables.$thumb-size})) / 2);
 		}
@@ -175,7 +177,7 @@ $track-thickness: 2px;
 	#{focus-variables.$focus-inset}: -3px;
 	#{focus-variables.$focus-stroke-gap-color}: transparent;
 
-	border-radius: 50%;
+	border-radius: #{border-radius-variables.$border-radius-full};
 
 	.control:not(:focus-visible) & {
 		display: none;

--- a/libs/components/src/lib/split-button/partials/variables.scss
+++ b/libs/components/src/lib/split-button/partials/variables.scss
@@ -2,3 +2,4 @@ $icon-gap: --_split-button-icon-gap;
 $block-size: --_split-button-block-size;
 $inline-size: --_split-button-inline-size;
 $split-button-line-clamp: --split-button-line-clamp;
+$border-radius: --_border-radius;

--- a/libs/components/src/lib/split-button/split-button.scss
+++ b/libs/components/src/lib/split-button/split-button.scss
@@ -17,6 +17,8 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
+
 
 :host {
 	display: inline-block;
@@ -59,6 +61,8 @@
 	border-inline-end: 0;
 	gap: var(#{variables.$icon-gap});
 	isolation: isolate;
+	border-top-left-radius: var(#{variables.$border-radius});
+	border-bottom-left-radius: var(#{variables.$border-radius});
 
 	&:focus-visible {
 		outline: none;
@@ -91,11 +95,14 @@
 
 	/* shape */
 	&:not(.shape-pill) {
-		border-radius: 6px 0 0 6px;
+		//border-radius: 6px 0 0 6px;
+		#{variables.$border-radius}: #{border-radius-variables.$border-radius-normal};
+
 	}
 
 	&.shape-pill {
-		border-radius: 24px 0 0 24px;
+		//border-radius: 24px 0 0 24px;
+		#{variables.$border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 	}
 
 	/* size */
@@ -124,6 +131,8 @@
 .indicator {
 	border-inline-start: 0;
 	inline-size: var(#{variables.$inline-size});
+	border-top-right-radius: var(#{variables.$border-radius});
+	border-bottom-right-radius: var(#{variables.$border-radius});
 
 	&:focus-visible {
 		outline: none;
@@ -140,11 +149,11 @@
 
 	/* Shape */
 	&:not(.shape-pill) {
-		border-radius: 0 6px 6px 0;
+		#{variables.$border-radius}: #{border-radius-variables.$border-radius-normal};
 	}
 
 	&.shape-pill {
-		border-radius: 0 24px 24px 0;
+		#{variables.$border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 	}
 
 	/* size */

--- a/libs/components/src/lib/split-button/split-button.scss
+++ b/libs/components/src/lib/split-button/split-button.scss
@@ -58,11 +58,11 @@
 }
 
 .control{
+	border-bottom-left-radius: var(#{variables.$border-radius});
 	border-inline-end: 0;
+	border-top-left-radius: var(#{variables.$border-radius});
 	gap: var(#{variables.$icon-gap});
 	isolation: isolate;
-	border-top-left-radius: var(#{variables.$border-radius});
-	border-bottom-left-radius: var(#{variables.$border-radius});
 
 	&:focus-visible {
 		outline: none;
@@ -95,13 +95,11 @@
 
 	/* shape */
 	&:not(.shape-pill) {
-		//border-radius: 6px 0 0 6px;
 		#{variables.$border-radius}: #{border-radius-variables.$border-radius-normal};
 
 	}
 
 	&.shape-pill {
-		//border-radius: 24px 0 0 24px;
 		#{variables.$border-radius}: #{border-radius-variables.$border-radius-extra-expanded};
 	}
 
@@ -129,10 +127,10 @@
 }
 
 .indicator {
-	border-inline-start: 0;
-	inline-size: var(#{variables.$inline-size});
-	border-top-right-radius: var(#{variables.$border-radius});
 	border-bottom-right-radius: var(#{variables.$border-radius});
+	border-inline-start: 0;
+	border-top-right-radius: var(#{variables.$border-radius});
+	inline-size: var(#{variables.$inline-size});
 
 	&:focus-visible {
 		outline: none;

--- a/libs/components/src/lib/switch/switch.scss
+++ b/libs/components/src/lib/switch/switch.scss
@@ -16,6 +16,8 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
+
 
 :host(.disabled) {
 	cursor: not-allowed;
@@ -111,7 +113,7 @@
 	#{focus-variables.$focus-inset}: -4px;
 	#{focus-variables.$focus-stroke-gap-color}: transparent;
 
-	border-radius: 14px;
+	border-radius: #{border-radius-variables.$border-radius-expanded};
 
 	.control:not(:focus-visible) & {
 		display: none;

--- a/libs/components/src/lib/switch/switch.scss
+++ b/libs/components/src/lib/switch/switch.scss
@@ -58,7 +58,7 @@
 	align-items: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
 	block-size: #{size.$vvd-size-ultra-condensed};
-	border-radius: calc(#{size.$vvd-size-ultra-condensed} / .5);
+	border-radius: #{border-radius-variables.$border-radius-super-expanded};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	inline-size: var(#{variables.$switch-inline-size});
 	transition: all 0.2s ease-in-out 0s;

--- a/libs/components/src/lib/tab/tab.scss
+++ b/libs/components/src/lib/tab/tab.scss
@@ -97,7 +97,7 @@ slot[name="icon"]{
 		position: absolute;
 		background: currentColor;
 		block-size: 2px;
-		border-radius: 2px;
+		border-radius: #{border-radius-variables.$border-radius-condensed};
 		content: "";
 		inline-size: 100%;
 		inset-block-end: 0;

--- a/libs/components/src/lib/tab/tab.scss
+++ b/libs/components/src/lib/tab/tab.scss
@@ -1,6 +1,7 @@
 @use "../tabs/partials/variables" as tabs-variables;
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent cta,
@@ -56,7 +57,7 @@
 	}
 
 	&:not(.shape-sharp) {
-		border-radius: 6px;
+		border-radius: #{border-radius-variables.$border-radius-normal};
 	}
 
 	&:not(.disabled) {

--- a/libs/components/src/lib/tabs/tabs.scss
+++ b/libs/components/src/lib/tabs/tabs.scss
@@ -13,6 +13,7 @@
 	$default: ghost
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 
 .base {
@@ -104,7 +105,7 @@
 	.base.orientation-vertical & {
 		align-self: center;
 		block-size: 80%;
-		border-radius: 2px;
+		border-radius: #{border-radius-variables.$border-radius-condensed};
 		grid-area: 1 / 1 / auto / auto;
 		inline-size: var(#{variables.$tabs-active-indicator-stroke-width});
 	}

--- a/libs/components/src/lib/tag/tag.scss
+++ b/libs/components/src/lib/tag/tag.scss
@@ -1,6 +1,7 @@
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "partials/variables" as variables;
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
 	$connotations: accent cta,
@@ -40,10 +41,10 @@
 
 	/* Shape */
 	&:not(.shape-pill) {
-		border-radius: 4px;
+		border-radius: #{border-radius-variables.$border-radius-semi-condensed};
 	}
 	&.shape-pill {
-		border-radius: 14px;
+		border-radius: #{border-radius-variables.$border-radius-expanded};
 	}
 
 	@supports selector(:focus-visible) {

--- a/libs/components/src/lib/text-area/text-area.scss
+++ b/libs/components/src/lib/text-area/text-area.scss
@@ -1,4 +1,5 @@
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
@@ -67,7 +68,7 @@ $outline-width: 2px;
 	border: 0 none;
 	appearance: none; /* for box-shadow visibility on IOS */
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	font: var(#{constants.$vvd-typography-base});

--- a/libs/components/src/lib/text-field/text-field.scss
+++ b/libs/components/src/lib/text-field/text-field.scss
@@ -1,5 +1,6 @@
 @use "partials/variables" as variables;
 @use "../focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @use "../../../../../dist/libs/tokens/scss/tokens.constants" as constants;
 @use "../../../../shared/src/lib/sass/mixins/connotation/config" with (
@@ -101,11 +102,11 @@ $low-ink-color: --_low-ink-color;
 
 	/* Shape */
 	.base:not(.shape-pill) & {
-		border-radius: 6px;
+		border-radius: #{border-radius-variables.$border-radius-normal};
 	}
 
 	.base.shape-pill & {
-		border-radius: 24px;
+		border-radius: #{border-radius-variables.$border-radius-extra-expanded};
 	}
 }
 

--- a/libs/components/src/lib/tree-item/tree-item.scss
+++ b/libs/components/src/lib/tree-item/tree-item.scss
@@ -16,6 +16,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../../../../dist/libs/tokens/scss/size.variables" as size;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 @supports selector(:focus-visible) {
 	:host(:focus-visible) {
@@ -40,7 +41,7 @@
 	box-sizing: border-box;
 	align-items: center;
 	background-color: var(#{appearance.get-appearance-token(fill)});
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	box-shadow: inset 0 0 0 1px var(#{appearance.get-appearance-token(outline)});
 	color: var(#{appearance.get-appearance-token(text)});
 	font: var(#{constants.$vvd-typography-base});
@@ -79,7 +80,7 @@
 .expandCollapseButton {
 	display: flex;
 	align-items: center;
-	border-radius: 6px;
+	border-radius: #{border-radius-variables.$border-radius-normal};
 	font-size: 20px;
 
 	.expandCollapseIcon {

--- a/libs/components/src/shared/date-picker/date-picker-base.scss
+++ b/libs/components/src/shared/date-picker/date-picker-base.scss
@@ -12,6 +12,7 @@
 );
 @use "../../../../shared/src/lib/sass/mixins/appearance" as appearance;
 @use "../../lib/focus/partials/variables" as focus-variables;
+@use "../../../../shared/src/lib/sass/mixins/border-radius" as border-radius-variables;
 
 :host {
 	display: inline-block;
@@ -65,7 +66,7 @@
 
 	.title-action {
 		block-size: 24px;
-		border-radius: 6px;
+		border-radius: #{border-radius-variables.$border-radius-normal};
 		font: var(#{constants.$vvd-typography-base-extended});
 		padding-inline: 6px;
 	}
@@ -106,7 +107,7 @@
 		justify-content: center;
 		aspect-ratio: 1/1;
 		block-size: 28px;
-		border-radius: 50%;
+		border-radius: #{border-radius-variables.$border-radius-full};
 		font: var(#{constants.$vvd-typography-base});
 		margin-inline: 6px;
 
@@ -175,7 +176,7 @@
 		justify-content: center;
 		aspect-ratio: 1/1;
 		block-size: 48px;
-		border-radius: 50%;
+		border-radius: #{border-radius-variables.$border-radius-full};
 		font: var(#{constants.$vvd-typography-base-extended});
 		text-transform: uppercase;
 

--- a/libs/shared/src/lib/sass/mixins/border-radius.scss
+++ b/libs/shared/src/lib/sass/mixins/border-radius.scss
@@ -1,0 +1,9 @@
+$border-radius-none: 0;
+$border-radius-condensed: 2px;
+$border-radius-semi-condensed: 4px;
+$border-radius-normal: 6px;
+$border-radius-expanded: 14px;
+$border-radius-extra-expanded: 24px;
+$border-radius-super-expanded: 40px;
+$border-radius-full: 50%;
+


### PR DESCRIPTION
moved all hard-coded values to use border-radius variables.
3 components are left out (VIV-1462)

left border-radius: inherit out of the variables.