### PR TITLE
fix(alert): add media query to set min-inline-size to auto (VIV-1564)

### DIFF
--- a/libs/components/src/lib/alert/alert.scss
+++ b/libs/components/src/lib/alert/alert.scss
@@ -70,6 +70,10 @@ $alert-transition-delay: --transition-delay;
 	max-inline-size: var(#{variables.$alert-max-inline-size}, fit-content);
 	min-inline-size: var(#{variables.$alert-min-inline-size}, 420px);
 	transition: opacity 150ms cubic-bezier(0, 0, 0.2, 1) 0ms, transform 150ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+
+	@media (max-width: 768px) {
+		min-inline-size: var(#{variables.$alert-min-inline-size}, auto);
+	}
 }
 
 .base {


### PR DESCRIPTION
This change is meant to address https://github.com/Vonage/vivid-3/issues/1511 by adding a media query to set the `min-inline-size` to auto when the viewport is smaller than 768px. It still takes the `$alert-min-inline-size` in case the user wants to override this value.
![image](https://github.com/Vonage/vivid-3/assets/43491324/8dc1d4f6-d4f9-41a4-8611-6221a8c5a3c0)
