### PR TITLE
feat(components): minify css (VIV-1376)

### DIFF
--- a/libs/components/vite.config.ts
+++ b/libs/components/vite.config.ts
@@ -94,6 +94,7 @@ export default defineConfig({
 			formats: ['es'],
 		},
 		minify: false,
+		cssMinify: true,
 		target: 'esnext',
 		rollupOptions: {
 			input,


### PR DESCRIPTION
As css is part included in the js bundle, it cannot be optimised later.

This change reduces bundle size of an empty Vue app from 748.78 kB -> 690.13 kB