### PR TITLE
fix(button): improve button accessibility (VIV-1505)

### DIFF
--- a/libs/components/src/lib/button/README.md
+++ b/libs/components/src/lib/button/README.md
@@ -199,7 +199,7 @@ If set, the `icon` attribute is ignored.
 			}
 	}
 </style>
-<vwc-button>
+<vwc-button aria-label="Mute">
   <vwc-icon slot="icon">
   	<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
   		<g>
@@ -213,6 +213,11 @@ If set, the `icon` attribute is ignored.
 ```
 
 ## Accessibility 
+
+Add an `aria-label` or `title` attribute if the button does not have a label or the label is not descriptive enough.
+
+Icons are purely decorative and are hidden from assistive technology. Ensure that the button's purpose is still clear without the icon.
+
 When deciding between `aria-label` or `title`, keep in mind that `aria-label` is better for accessibility.  
 The assistive technology will read the `aria-label` text rather than the `title` if both are set.
 

--- a/libs/components/src/lib/button/button.template.ts
+++ b/libs/components/src/lib/button/button.template.ts
@@ -4,7 +4,7 @@ import type { ElementDefinitionContext, FoundationElementDefinition } from '@mic
 import { classNames } from '@microsoft/fast-web-utilities';
 import { ProgressRing } from '../progress-ring/progress-ring';
 import { Size } from '../enums';
-import { affixIconTemplateFactory, IconWrapper } from '../../shared/patterns/affix';
+import { affixIconTemplateFactory, IconAriaHidden, IconWrapper } from '../../shared/patterns/affix';
 import type { Button, ButtonAppearance, ButtonSize } from './button';
 
 
@@ -44,7 +44,7 @@ function renderIconOrPending(
 
 	} else {
 		const affixIconTemplate = affixIconTemplateFactory(context);
-		return affixIconTemplate(icon, IconWrapper.Slot);
+		return affixIconTemplate(icon, IconWrapper.Slot, IconAriaHidden.Hidden);
 	}
 }
 
@@ -60,39 +60,41 @@ export const buttonTemplate: (
 ) => ViewTemplate<Button> = (context: ElementDefinitionContext) => {
 
 	return html`
-	<button
-		class="${getClasses}"
-		?autofocus="${(x) => x.autofocus}"
-		?disabled="${(x) => x.disabled || x.pending}"
-		form="${(x) => x.formId}"
-		formaction="${(x) => x.formaction}"
-		formenctype="${(x) => x.formenctype}"
-		formmethod="${(x) => x.formmethod}"
-		formnovalidate="${(x) => x.formnovalidate}"
-		formtarget="${(x) => x.formtarget}"
-		name="${(x) => x.name}"
-		type="${(x) => x.type}"
-		value="${(x) => x.value}"
-		aria-atomic="${(x) => x.ariaAtomic}"
-		aria-busy="${(x) => x.ariaBusy}"
-		aria-current="${(x) => x.ariaCurrent}"
-		aria-details="${(x) => x.ariaDetails}"
-		aria-disabled="${(x) => x.ariaDisabled}"
-		aria-expanded="${(x) => x.ariaExpanded}"
-		aria-haspopup="${(x) => x.ariaHaspopup}"
-		aria-hidden="${(x) => x.ariaHidden}"
-		aria-invalid="${(x) => x.ariaInvalid}"
-		aria-keyshortcuts="${(x) => x.ariaKeyshortcuts}"
-		aria-label="${(x) => x.ariaLabel}"
-		aria-live="${(x) => x.ariaLive}"
-		aria-pressed="${(x) => x.ariaPressed}"
-		aria-relevant="${(x) => x.ariaRelevant}"
-		aria-roledescription="${(x) => x.ariaRoledescription}"
-		title="${x => x.title}"
-		${ref('control')}
-	>
-		${x => renderIconOrPending(context, x.icon, x.pending, x.size)}
-		${when(x => x.label, html`<span class="text">${(x) => x.label}</span>`)}
-	</button>
+		<template role="presentation">
+			<button
+				class="${getClasses}"
+				?autofocus="${(x) => x.autofocus}"
+				?disabled="${(x) => x.disabled || x.pending}"
+				form="${(x) => x.formId}"
+				formaction="${(x) => x.formaction}"
+				formenctype="${(x) => x.formenctype}"
+				formmethod="${(x) => x.formmethod}"
+				formnovalidate="${(x) => x.formnovalidate}"
+				formtarget="${(x) => x.formtarget}"
+				name="${(x) => x.name}"
+				type="${(x) => x.type}"
+				value="${(x) => x.value}"
+				aria-atomic="${(x) => x.ariaAtomic}"
+				aria-busy="${(x) => x.ariaBusy}"
+				aria-current="${(x) => x.ariaCurrent}"
+				aria-details="${(x) => x.ariaDetails}"
+				aria-disabled="${(x) => x.ariaDisabled}"
+				aria-expanded="${(x) => x.ariaExpanded}"
+				aria-haspopup="${(x) => x.ariaHaspopup}"
+				aria-hidden="${(x) => x.ariaHidden}"
+				aria-invalid="${(x) => x.ariaInvalid}"
+				aria-keyshortcuts="${(x) => x.ariaKeyshortcuts}"
+				aria-label="${(x) => x.ariaLabel}"
+				aria-live="${(x) => x.ariaLive}"
+				aria-pressed="${(x) => x.ariaPressed}"
+				aria-relevant="${(x) => x.ariaRelevant}"
+				aria-roledescription="${(x) => x.ariaRoledescription}"
+				title="${x => x.title}"
+				${ref('control')}
+			>
+				${x => renderIconOrPending(context, x.icon, x.pending, x.size)}
+				${when(x => x.label, html`<span class="text" role="presentation">${(x) => x.label}</span>`)}
+			</button>
+		</template>
 `;
 };

--- a/libs/components/src/shared/patterns/affix.ts
+++ b/libs/components/src/shared/patterns/affix.ts
@@ -51,23 +51,27 @@ export const IconWrapper = {
 	Span: true
 };
 
+export const IconAriaHidden = {
+	Hidden: 'true',
+	Visible: 'false'
+};
+
 type affixIconTemplateFactoryReturnType = (context: ElementDefinitionContext) =>
-(icon?: string, slottedState?: boolean, iconSlottedContent?: string) =>
+(icon?: string, slottedState?: boolean, ariaHidden?: string) =>
 ViewTemplate<AffixIcon> | null
 /**
  * The template for the prefixed element.
  * For use with {@link AffixIcon}
  *
  * @param context - element definition context
- * @param slottedState - set the icon in a span with class "icon", defaults to false
  * @public
  */
 export const affixIconTemplateFactory: affixIconTemplateFactoryReturnType = (context: ElementDefinitionContext) => {
 
 	const iconTag = context.tagFor(Icon);
-	return (icon?: string, slottedState = IconWrapper.Span) => {
+	return (icon?: string, slottedState = IconWrapper.Span, ariaHidden = IconAriaHidden.Visible) => {
 		if (!icon && !slottedState) {
-			return html`<slot name="icon" ${slotted('iconSlottedContent')}></slot>`;
+			return html`<slot name="icon" aria-hidden="${() => ariaHidden}" ${slotted('iconSlottedContent')}></slot>`;
 		}
 		if (!icon && slottedState) {
 			return null;
@@ -75,7 +79,7 @@ export const affixIconTemplateFactory: affixIconTemplateFactoryReturnType = (con
 
 		const iconTemplate = html`<${iconTag} :name="${() => icon}"></${iconTag}>`;
 
-		return slottedState ? html`<span class="icon">${iconTemplate}</span>`
-			:  html`<slot name="icon">${iconTemplate}</slot>`;
+		return slottedState ? html`<span class="icon" aria-hidden="${() => ariaHidden}">${iconTemplate}</span>`
+			:  html`<slot name="icon" aria-hidden="${() => ariaHidden}">${iconTemplate}</slot>`;
 	};
 };


### PR DESCRIPTION
Most buttons are announced as button now:

* `<vwc-button label="Click me"></vwc-button>` -> "Click me, button"
* `<vwc-button icon="icon" label="Click me"></vwc-button>` -> "Click me, button"
* `<vwc-button icon="icon" title="Click me"></vwc-button>` -> "Click me, button"

However, when using icon button with `aria-label` it is still announced as group:

* `<vwc-button icon="icon" aria-label="Click me"></vwc-button>` -> "Click me, group"

I don't think this can be easily fixed due to how our button works.


