### PR TITLE
Viv 000 docs roadmap update

### DIFF
--- a/apps/docs/pages/component-pages.njk
+++ b/apps/docs/pages/component-pages.njk
@@ -15,7 +15,7 @@ permalink: "components/{{ component | pageSlug }}/"
 
 	{% block banner %}
 		{% if (component.status == "alpha") %}
-			<vwc-banner class="banner" text="Alpha: this is the initial phase of component testing. Expect breaking changes." connotation="warning"></vwc-banner>
+			<vwc-banner class="banner" text="ALPHA: If you need this component, please contact the Vivid team to co-ordinate acceptence testing" connotation="warning"></vwc-banner>
 		{% endif %}
 		{% if (component.status == "underlying") %}
 			<vwc-banner class="banner" text="Underlying: this component is only used by other components and not intended to be used by authors outside the Vivid team" connotation="information"></vwc-banner>

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## In Progress
+## Upcoming components
 
 <style>
   @media screen and (max-width: 768px){
@@ -34,7 +34,7 @@
       Design
     </vwc-data-grid-cell>
     <vwc-data-grid-cell cell-type="columnheader" role="columnheader">
-      Alpha release
+      Alpha
     </vwc-data-grid-cell>
   </vwc-data-grid-row>
   <vwc-data-grid-row>
@@ -95,3 +95,11 @@
   </vwc-data-grid-row>
 </vwc-data-grid>
 </vwc-elevation>
+
+### Key
+
+| Phase | Description |
+| --- | --- |
+| Discovery | Validate the shared value of the feature and that we understand the problem well enough to commit further resources. |
+| Design | Ensure designs meet user needs while upholding our brand standards and visual language. |
+| Alpha| Component is available and documentation is published. Awaiting acceptence testing by at least 2 teams |

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -34,35 +34,7 @@
       Design
     </vwc-data-grid-cell>
     <vwc-data-grid-cell cell-type="columnheader" role="columnheader">
-      Development
-    </vwc-data-grid-cell>
-  </vwc-data-grid-row>
-  <vwc-data-grid-row>
-    <vwc-data-grid-cell>
-      Video Player
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-      <vwc-button label="In Progress" target="_blank" href="https://confluence.vonage.com/display/VIVID/Video+component+spike" connotation="cta"></vwc-button>
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-      <vwc-button label="In Progress" target="_blank" href="https://www.figma.com/file/tWEyQlBY6cBymajaJPLSy0/Vivid-3.0-WIP-Drafts?type=design&node-id=23%3A13702&mode=design&t=PGI1aODhsHS1YDhV-1" connotation="cta"></vwc-button>
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-      <vwc-button label="In progress" target="_blank" href="https://jira.vonage.com/browse/VIV-1486" connotation="cta"></vwc-button>
-    </vwc-data-grid-cell>
-  </vwc-data-grid-row>
-  <vwc-data-grid-row>
-    <vwc-data-grid-cell>
-      Range Slider
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-      <vwc-button label="Done" target="_blank" href="https://confluence.vonage.com/display/VIVID/Range+slider" connotation="success"></vwc-button>
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-    <vwc-button label="Done" target="_blank" href="https://www.figma.com/file/JJNgZvt1qf3ydYmOwbE3Jg/Vivid-UI-Kit---3.0-WIP?type=design&node-id=31345%3A96328&mode=design&t=QNhBeU12Gu7dtS7N-1" connotation="success"></vwc-button>
-    </vwc-data-grid-cell>
-    <vwc-data-grid-cell>
-      <vwc-button label="In Progress" target="_blank" href="https://jira.vonage.com/browse/VIV-1488" connotation="cta"></vwc-button>
+      Alpha release
     </vwc-data-grid-cell>
   </vwc-data-grid-row>
   <vwc-data-grid-row>
@@ -70,45 +42,56 @@
       Dial Pad
     </vwc-data-grid-cell>
     <vwc-data-grid-cell>
-      <vwc-button label="Done" target="_blank" href="https://confluence.vonage.com/pages/viewpage.action?spaceKey=VIVID&title=Dial+pad" connotation="success"></vwc-button>
+      <vwc-button label="Done" target="_blank" href="https://confluence.vonage.com/pages/viewpage.action?spaceKey=VIVID&title=Dial+pad" icon="check" connotation="success"></vwc-button>
     </vwc-data-grid-cell>
     <vwc-data-grid-cell>
-    <vwc-button label="In Progress" target="_blank" href="https://www.figma.com/file/tWEyQlBY6cBymajaJPLSy0/Vivid-3.0-WIP-Drafts?type=design&node-id=67-39674&mode=design&t=X4VuTNKdOR3AX037-0" connotation="cta"></vwc-button>
+    <vwc-button label="In Progress" target="_blank" href="https://www.figma.com/file/tWEyQlBY6cBymajaJPLSy0/Vivid-3.0-WIP-Drafts?type=design&node-id=67-39674&mode=design&t=X4VuTNKdOR3AX037-0" icon="more-horizontal-line" connotation="cta"></vwc-button>
     </vwc-data-grid-cell>
     <vwc-data-grid-cell>
-      <vwc-button label="In Progress" target="_blank" href="https://jira.vonage.com/browse/VIV-1512" connotation="cta"></vwc-button>
+      <vwc-button label="Exp: 04/2024" icon="more-horizontal-line" target="_blank" href="https://jira.vonage.com/browse/VIV-1512" connotation="cta"></vwc-button>
     </vwc-data-grid-cell>
   </vwc-data-grid-row>
-</vwc-data-grid>
-</vwc-elevation>
-
-
-## Completed
-
-{% assign sortedComponents = components | sort: 'title' %}
-
-<vwc-elevation dp="2">
-<vwc-data-grid>
-  <vwc-data-grid-row row-type="header">
-    <vwc-data-grid-cell cell-type="columnheader">
-      Name
+  <vwc-data-grid-row>
+    <vwc-data-grid-cell>
+      <a href="/components/range-slider">Range Slider</a>
     </vwc-data-grid-cell>
-    <vwc-data-grid-cell cell-type="columnheader">
-      Status
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" target="_blank" href="https://confluence.vonage.com/display/VIVID/Range+slider" icon="check" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+    <vwc-button label="Done" target="_blank" href="https://www.figma.com/file/JJNgZvt1qf3ydYmOwbE3Jg/Vivid-UI-Kit---3.0-WIP?type=design&node-id=31345%3A96328&mode=design&t=QNhBeU12Gu7dtS7N-1" icon="check" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" icon="check" href="/components/range-slider" connotation="success"></vwc-button>
     </vwc-data-grid-cell>
   </vwc-data-grid-row>
-{% for item in sortedComponents)
-	%}<vwc-data-grid-row>
-		<vwc-data-grid-cell>
-			{{ item.title }}
-		</vwc-data-grid-cell>
-		<vwc-data-grid-cell>
-				<vwc-badge appearance='subtle' 
-						text='{% if item.status == 'alpha' %}Alpha{% else %}GA{% endif %}'
-						connotation='{% if item.status == 'alpha' %}warning{% else %}success{% endif %}'
-				></vwc-badge>
-		</vwc-data-grid-cell>
-	</vwc-data-grid-row>{%
-endfor %}
+  <vwc-data-grid-row>
+    <vwc-data-grid-cell>
+      <a href="/components/time-picker">Time Picker</a>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" icon="check" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+    <vwc-button label="Done" target="_blank" href="https://www.figma.com/file/JJNgZvt1qf3ydYmOwbE3Jg/Vivid-UI-Kit---3.0-WIP?type=design&node-id=31345%3A96328&mode=design&t=QNhBeU12Gu7dtS7N-1" icon="check" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" icon="check" href="/components/time-picker" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+  </vwc-data-grid-row>
+  <vwc-data-grid-row>
+    <vwc-data-grid-cell>
+      Video Player
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" icon="check" target="_blank" icon="check" href="https://confluence.vonage.com/display/VIVID/Video+player" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Done" icon="check" target="_blank" href="https://www.figma.com/file/tWEyQlBY6cBymajaJPLSy0/Vivid-3.0-WIP-Drafts?type=design&node-id=23%3A13702&mode=design&t=PGI1aODhsHS1YDhV-1" connotation="success"></vwc-button>
+    </vwc-data-grid-cell>
+    <vwc-data-grid-cell>
+      <vwc-button label="Exp: 03/2024" icon="more-horizontal-line" target="_blank" href="https://jira.vonage.com/browse/VIV-1486" connotation="cta"></vwc-button>
+    </vwc-data-grid-cell>
+  </vwc-data-grid-row>
 </vwc-data-grid>
 </vwc-elevation>


### PR DESCRIPTION
Update to the roadmap page:

Removes fully released components table
Adds Alpha components to the roadmap and links to their docs page when done
Changes Dev to Alpha and adds a key to describe the phases in the table
Changes the Alpha message on the alpha component page