### PR TITLE
chore(text-anchor): adding connotation & appearance (VIV-1668)

### DIFF
--- a/libs/components/src/lib/text-anchor/definition.ts
+++ b/libs/components/src/lib/text-anchor/definition.ts
@@ -4,6 +4,11 @@ import { registerFactory } from '../../shared/design-system';
 import { TextAnchor } from './text-anchor';
 import { textAnchorTemplate as template } from './text-anchor.template';
 
+export type {
+	TextAnchorConnotation,
+	TextAnchorAppearance,
+} from './text-anchor';
+
 /**
  * The text-anchor element.
  */

--- a/libs/components/src/lib/text-anchor/text-anchor.spec.ts
+++ b/libs/components/src/lib/text-anchor/text-anchor.spec.ts
@@ -1,6 +1,12 @@
-import { axe, elementUpdated, fixture, setAttribute } from '@vivid-nx/shared';
+import {
+	axe,
+	elementUpdated,
+	fixture,
+	getControlElement,
+	setAttribute,
+} from '@vivid-nx/shared';
 import { FoundationElementRegistry } from '@microsoft/fast-foundation';
-import { TextAnchor } from './text-anchor';
+import { TextAnchor, TextAnchorConnotation } from './text-anchor';
 import '.';
 import { textAnchorDefinition } from './definition';
 
@@ -166,6 +172,38 @@ describe('vwc-text-anchor', () => {
 			await elementUpdated(element);
 
 			expect(await axe(element)).toHaveNoViolations();
+		});
+	});
+
+	describe('text-anchor appearance', function () {
+		it('should set the appearance class on the control', async function () {
+			const appearance = 'ghost';
+
+			(element as any).appearance = appearance;
+			await elementUpdated(element);
+
+			const control = element.shadowRoot?.querySelector(`.control`);
+			expect(
+				control?.classList.contains(`appearance-${appearance}`)
+			).toBeTruthy();
+		});
+	});
+
+	describe('text-anchor connotation', function () {
+		it('should set the connotation class on control', async function () {
+			const connotation = 'cta' as TextAnchorConnotation;
+			expect(
+				getControlElement(element).classList.contains(
+					`connotation-${connotation}`
+				)
+			).toBeFalsy();
+			element.connotation = connotation;
+			await elementUpdated(element);
+			expect(
+				getControlElement(element).classList.contains(
+					`connotation-${connotation}`
+				)
+			).toBeTruthy();
 		});
 	});
 });

--- a/libs/components/src/lib/text-anchor/text-anchor.template.ts
+++ b/libs/components/src/lib/text-anchor/text-anchor.template.ts
@@ -11,8 +11,13 @@ import {
 } from '../../shared/patterns/affix';
 import type { TextAnchor } from './text-anchor';
 
-const getClasses = ({ text }: TextAnchor) =>
-	classNames('control', ['icon-only', !text]);
+const getClasses = ({ text, connotation, appearance }: TextAnchor) =>
+	classNames(
+		'control',
+		['icon-only', !text],
+		[`connotation-${connotation}`, Boolean(connotation)],
+		[`appearance-${appearance}`, Boolean(appearance)]
+	);
 
 /**
  * The template for the (Anchor:class) component.

--- a/libs/components/src/lib/text-anchor/text-anchor.ts
+++ b/libs/components/src/lib/text-anchor/text-anchor.ts
@@ -1,6 +1,24 @@
 import { Anchor, applyMixins } from '@microsoft/fast-foundation';
 import { attr, ViewTemplate } from '@microsoft/fast-element';
+import { Appearance, Connotation } from '../enums';
 import { AffixIcon } from '../../shared/patterns/affix';
+
+/**
+ * Types of text anchor connotation.
+ *
+ * @public
+ */
+export type TextAnchorConnotation = Extract<
+	Connotation,
+	Connotation.Accent | Connotation.CTA
+>;
+
+/**
+ * Types of button appearance.
+ *
+ * @public
+ */
+export type TextAnchorAppearance = Extract<Appearance, Appearance.Ghost>;
 
 /**
  * @component text-anchor
@@ -15,6 +33,24 @@ export class TextAnchor extends Anchor {
 	 * HTML Attribute: text
 	 */
 	@attr text?: string;
+
+	/**
+	 * The connotation Text-Anchor should have.
+	 *
+	 * @public
+	 * @remarks
+	 * HTML Attribute: connotation
+	 */
+	@attr connotation?: TextAnchorConnotation;
+
+	/**
+	 * The appearance Text-Anchor should have.
+	 *
+	 * @public
+	 * @remarks
+	 * HTML Attribute: appearance
+	 */
+	@attr appearance?: TextAnchorAppearance;
 
 	/**
 	 * Allows subclasses to provide a body template that will be rendered inside the anchor.


### PR DESCRIPTION
This is part of nav-item enhancement with additional connotation (CTA) and appearance (ghost-opacity)