### PR TITLE
fix(a11y): error message announcement in form elements (VIV-1593)

### DIFF
--- a/libs/components/src/lib/date-range-picker/ui.test.ts
+++ b/libs/components/src/lib/date-range-picker/ui.test.ts
@@ -185,7 +185,7 @@ test.describe('constraints validation', async () => {
 
 		await expect(
 			page.locator('vwc-date-range-picker .error-message')
-		).toBeVisible();
+		).not.toHaveClass(/sr-only/);
 	});
 
 	test('should hide a validation error after resetting the form', async ({
@@ -206,6 +206,6 @@ test.describe('constraints validation', async () => {
 
 		await expect(
 			page.locator('vwc-date-range-picker .error-message')
-		).not.toBeVisible();
+		).toHaveClass(/sr-only/);
 	});
 });

--- a/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
+++ b/libs/components/src/shared/patterns/form-elements/form-elements.spec.ts
@@ -347,7 +347,7 @@ describe('getFeedbackTemplate', () => {
 
 	const getMessage = (type: string) => {
 		const messageEl = element.shadowRoot!.querySelector(
-			`.${type}-message.message--visible`
+			`.${type}-message.message--visible:not(.sr-only)`
 		);
 		if (!messageEl) {
 			return null;

--- a/libs/components/src/shared/patterns/form-elements/form-elements.ts
+++ b/libs/components/src/shared/patterns/form-elements/form-elements.ts
@@ -176,7 +176,7 @@ type FeedbackConfig = {
 		name: string;
 		slottedContentProperty: '_helperTextSlottedContent';
 	};
-	role: 'status' | 'none'
+	role: 'status' | 'none';
 };
 const feedback: Record<string, FeedbackConfig> = {
 	helper: {
@@ -186,19 +186,19 @@ const feedback: Record<string, FeedbackConfig> = {
 			name: 'helper-text',
 			slottedContentProperty: '_helperTextSlottedContent',
 		},
-		role: 'none'
+		role: 'none',
 	},
 	error: {
 		messageProperty: 'errorValidationMessage',
 		className: 'error',
 		iconType: 'info-line',
-		role: 'status'
+		role: 'status',
 	},
 	success: {
 		messageProperty: 'successText',
 		className: 'success',
 		iconType: 'check-circle-line',
-		role: 'none'
+		role: 'none',
 	},
 };
 

--- a/libs/components/src/shared/patterns/form-elements/form-elements.ts
+++ b/libs/components/src/shared/patterns/form-elements/form-elements.ts
@@ -249,10 +249,16 @@ function getFeedbackTypeTemplate(
 
 	return html<SomeFormElement>`<div
 		class="${(x) =>
-			classNames('message', `${config.className}-message`, [
-				'message--visible',
-				shouldShow(x),
-			])}"
+			classNames(
+				'message',
+				`${config.className}-message`,
+				['message--visible', shouldShow(x)],
+				['sr-only', !shouldShow(x)]
+			)}"
+		role="${config.messageProperty === 'errorValidationMessage'
+			? 'status'
+			: 'none'}"
+		aria-atomic="false"
 	>
 		${when(
 			(x) => shouldShow(x) && config.iconType,

--- a/libs/components/src/shared/patterns/form-elements/message.scss
+++ b/libs/components/src/shared/patterns/form-elements/message.scss
@@ -5,8 +5,8 @@ $low-ink-color: --_low-ink-color;
 .sr-only {
 	position: absolute;
 	overflow: hidden;
-	height: 1px;
 	width: 1px;
+	height: 1px;
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
 	white-space: nowrap;
@@ -25,9 +25,6 @@ $low-ink-color: --_low-ink-color;
 
 	&--visible {
 		display: flex;
-		width: auto;
-		height: auto;
-		overflow: auto;
 	}
 
 	&-text {

--- a/libs/components/src/shared/patterns/form-elements/message.scss
+++ b/libs/components/src/shared/patterns/form-elements/message.scss
@@ -2,14 +2,14 @@
 
 $low-ink-color: --_low-ink-color;
 
-.sr-only:not(:focus):not(:active) {
+.sr-only {
+	position: absolute;
+	overflow: hidden;
+	height: 1px;
+	width: 1px;
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
 	white-space: nowrap;
-	width: 1px;
 }
 
 .message {

--- a/libs/components/src/shared/patterns/form-elements/message.scss
+++ b/libs/components/src/shared/patterns/form-elements/message.scss
@@ -2,6 +2,16 @@
 
 $low-ink-color: --_low-ink-color;
 
+.sr-only:not(:focus):not(:active) {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
 .message {
 	display: none;
 	contain: inline-size;
@@ -9,8 +19,15 @@ $low-ink-color: --_low-ink-color;
 	gap: 4px;
 	grid-column: 1 / -1;
 
+	&.error-message {
+		display: flex;
+	}
+
 	&--visible {
 		display: flex;
+		width: auto;
+		height: auto;
+		overflow: auto;
 	}
 
 	&-text {

--- a/libs/shared/src/lib/test-utils/index.ts
+++ b/libs/shared/src/lib/test-utils/index.ts
@@ -32,9 +32,8 @@ export const getControlElement = (element: Element) => {
 	return element.shadowRoot?.querySelector('.control') as HTMLElement;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function setAttribute(
-	element: any,
+	element: any, // eslint-disable-line @typescript-eslint/no-explicit-any
 	attribute: string,
 	value: string
 ) {

--- a/libs/shared/src/lib/test-utils/index.ts
+++ b/libs/shared/src/lib/test-utils/index.ts
@@ -32,17 +32,10 @@ export const getControlElement = (element: Element) => {
 	return element.shadowRoot?.querySelector('.control') as HTMLElement;
 };
 
-<<<<<<< HEAD
-export async function setAttribute(
-	element: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-	attribute: string,
-	value: string
-=======
 export async function setProperty<T extends Element, P extends keyof T>(
 	element: T,
 	property: P,
 	value: T[P]
->>>>>>> main
 ) {
 	element[property] = value;
 	await elementUpdated(element);


### PR DESCRIPTION
This can be tested by dynamically adding the `error-text` and the screen reader should announce it.