### PR TITLE
fix(ci): fix codecov token not being passed (VIV-000)

### DIFF
--- a/.github/workflows/_upload-coverage.yml
+++ b/.github/workflows/_upload-coverage.yml
@@ -8,6 +8,9 @@ on:
         description: Operating System to run the workflow on
         default: 'ubuntu-latest'
         required: false
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   test:
@@ -21,7 +24,7 @@ jobs:
           name: coverage
           path: ./coverage
 
-      - name: Upload coverage to Codecov with retry
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,6 +67,7 @@ jobs:
     uses: ./.github/workflows/_upload-coverage.yml
     with:
       os: ubuntu-latest
+    secrets: inherit
 
   call-visual-regression:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Finally figured out why the token was not being used which caused occasional failures when uploading coverage.

Now we get:
```diff
- ['info'] -> No token specified or token is empty
+ ['info'] ->  Token found by environment variables
```