### PR TITLE
feat(vue-wrappers): emit event types (VIV-1762)

### DIFF
--- a/libs/wrapper-gen/src/generator/__fixtures__/componentDefs.ts
+++ b/libs/wrapper-gen/src/generator/__fixtures__/componentDefs.ts
@@ -94,8 +94,8 @@ export const exampleComponent: ComponentDef = {
 			name: 'input:start',
 			type: [
 				{
-					text: 'Event',
-					vuePropType: 'Event',
+					text: 'CustomEvent<{a: string | number}>',
+					vuePropType: 'CustomEvent',
 				},
 			],
 		},

--- a/libs/wrapper-gen/src/generator/__snapshots__/renderComponent.spec.ts.snap
+++ b/libs/wrapper-gen/src/generator/__snapshots__/renderComponent.spec.ts.snap
@@ -38,33 +38,32 @@ export default defineComponent({
         start: {type: String as PropType<string>, default: undefined}
   },
   emits: [
-    
-        /**
+			
+						/**
  * This is an example event
  * @type {string}
  */
-        'example-event',
+							'example-event',
 
-        /**
+						/**
  * @type {Event}
  */
-        'input',
+							'input',
 
-        /**
- * @type {Event}
+						/**
+ * @type {CustomEvent<{a: string | number}>}
  */
-        'input:start',
+							'input:start',
 
-        /**
+						/**
  * @type {string}
  */
-        'update:modelValue',
+							'update:modelValue',
 
-        /**
+						/**
  * @type {string}
  */
-        'update:start'
-  ],
+							'update:start'],
   methods: {
   	
         /**
@@ -164,34 +163,33 @@ export default defineComponent({
 
         start: {type: String as PropType<string>, default: undefined}
   },
-  emits: [
-    
-        /**
+  emits: {
+			
+						/**
  * This is an example event
  * @type {string}
  */
-        'example-event',
+						['example-event'](event: string) { return true },
 
-        /**
+						/**
  * @type {Event}
  */
-        'input',
+						['input'](event: Event) { return true },
 
-        /**
- * @type {Event}
+						/**
+ * @type {CustomEvent<{a: string | number}>}
  */
-        'input:start',
+						['input:start'](event: CustomEvent<{a: string | number}>) { return true },
 
-        /**
+						/**
  * @type {string}
  */
-        'update:modelValue',
+						['update:modelValue'](event: string) { return true },
 
-        /**
+						/**
  * @type {string}
  */
-        'update:start'
-  ],
+						['update:start'](event: string) { return true }},
   methods: {
   	
         /**
@@ -240,8 +238,7 @@ export default defineComponent({
     
   },
   emits: [
-    
-  ],
+			],
   methods: {
   	
 	},
@@ -300,9 +297,8 @@ export default defineComponent({
   props: {
     
   },
-  emits: [
-    
-  ],
+  emits: {
+			},
   methods: {
   	
 	},

--- a/libs/wrapper-gen/src/generator/renderComponent.ts
+++ b/libs/wrapper-gen/src/generator/renderComponent.ts
@@ -271,13 +271,23 @@ export const renderComponent = (
 		.join(',\n');
 
 	// Declare events
-	const eventDefinitionsSrc = declaredEvents
-		.map(
-			({ name, description, type }) => `
-        ${renderJsDoc(description, type)}
-        '${name}'`
-		)
-		.join(',\n');
+	const eventDefinitionsSrc = isVue3Stub
+		? `{
+			${declaredEvents
+				.map(
+					({ name, description, type }) => `
+						${renderJsDoc(description, type)}
+						['${name}'](event: ${type.map((t) => t.text).join(' | ')}) { return true }`
+				)
+				.join(',\n')}}`
+		: `[
+			${declaredEvents
+				.map(
+					({ name, description, type }) => `
+						${renderJsDoc(description, type)}
+							'${name}'`
+				)
+				.join(',\n')}]`;
 
 	// For vue2, we rename v-model prop and event to the vue3 default names
 	const vue2VModelSrc = vueModels.some((model) => model.name === 'modelValue')
@@ -349,9 +359,7 @@ export default defineComponent({
   props: {
     ${propDefinitionsSrc}
   },
-  emits: [
-    ${eventDefinitionsSrc}
-  ],
+  emits: ${eventDefinitionsSrc},
   methods: {
   	${methodDefinitionsSrc}
 	},


### PR DESCRIPTION
Emit type annotations for events. However, this works for Vue 3 only as Vue 2 doesn't seem to allow typing events

![image](https://github.com/Vonage/vivid-3/assets/86777660/84111672-df80-4813-8797-2a01c4eefd3b)
