### PR TITLE
fix(vue-wrappers): fix handling of boolean attributes in Vue 3 (VIV-1898)

### DIFF
--- a/libs/wrapper-gen/src/generator/ComponentDef.ts
+++ b/libs/wrapper-gen/src/generator/ComponentDef.ts
@@ -13,6 +13,7 @@ export interface ComponentDef {
 		| {
 					type: 'attribute';
 					name: string; // Name of the attribute on the vivid component. E.g. action-href
+					boolean?: boolean;
 			  }
 			| {
 					type: 'property';

--- a/libs/wrapper-gen/src/generator/__fixtures__/componentDefs.ts
+++ b/libs/wrapper-gen/src/generator/__fixtures__/componentDefs.ts
@@ -102,6 +102,20 @@ export const exampleComponent: ComponentDef = {
 				},
 			],
 		},
+		{
+			name: 'boolean-attribute',
+			forwardTo: {
+				type: 'attribute',
+				name: 'boolean-attribute',
+				boolean: true,
+			},
+			type: [
+				{
+					text: 'boolean',
+					vuePropType: 'Boolean',
+				},
+			],
+		},
 	],
 	events: [
 		{

--- a/libs/wrapper-gen/src/generator/__snapshots__/renderComponent.spec.ts.snap
+++ b/libs/wrapper-gen/src/generator/__snapshots__/renderComponent.spec.ts.snap
@@ -37,7 +37,9 @@ export default defineComponent({
 
         start: {type: String as PropType<string>, default: undefined},
 
-        forcedDomProp: {type: String as PropType<string>, default: undefined}
+        forcedDomProp: {type: String as PropType<string>, default: undefined},
+
+        booleanAttribute: {type: Boolean as PropType<boolean>, default: undefined}
   },
   emits: [
 			
@@ -86,9 +88,9 @@ export default defineComponent({
     if (isVue2) {
         return h(this.componentName, {
             ref: 'element',
-            attrs: { ...(this.exampleAttribute !== undefined ? {'example-attribute': this.exampleAttribute } : {}),...(this.typeUnion !== undefined ? {'type-union': this.typeUnion } : {}),...(this.modelValue ?? this.value !== undefined ? {'value': this.modelValue ?? this.value } : {}),...(this.start !== undefined ? {'start': this.start } : {}) },
+            attrs: { ...((this.exampleAttribute) !== undefined ? {'example-attribute': this.exampleAttribute } : {}),...((this.typeUnion) !== undefined ? {'type-union': this.typeUnion } : {}),...((this.modelValue ?? this.value) !== undefined ? {'value': this.modelValue ?? this.value } : {}),...((this.start) !== undefined ? {'start': this.start } : {}),...((this.booleanAttribute) !== undefined ? {'boolean-attribute': this.booleanAttribute } : {}) },
             class: 'vvd-component',
-            domProps: { ...(this.importedType !== undefined ? {'importedType': this.importedType } : {}),...(this.forcedDomProp !== undefined ? {'forcedDomProp': this.forcedDomProp } : {}) },
+            domProps: { ...((this.importedType) !== undefined ? {'importedType': this.importedType } : {}),...((this.forcedDomProp) !== undefined ? {'forcedDomProp': this.forcedDomProp } : {}) },
             on: { 'example-event': (event: Event) => this.$emit('example-event', event),'input': (event: Event) => {
           this.$emit('update:modelValue', (event.target as any).value);
           this.$emit('input', event);
@@ -107,7 +109,7 @@ export default defineComponent({
       return h(this.componentName, {
           ref: 'element',
           class: 'vvd-component',
-          ...(this.exampleAttribute !== undefined ? {'^example-attribute': this.exampleAttribute } : {}),...(this.typeUnion !== undefined ? {'^type-union': this.typeUnion } : {}),...(this.importedType !== undefined ? {'.importedType': this.importedType } : {}),...(this.modelValue ?? this.value !== undefined ? {'^value': this.modelValue ?? this.value } : {}),...(this.start !== undefined ? {'^start': this.start } : {}),...(this.forcedDomProp !== undefined ? {'.forcedDomProp': this.forcedDomProp } : {}),'onExampleEvent': (event: Event) => this.$emit('example-event', event),'onInput': (event: Event) => {
+          ...((this.exampleAttribute) !== undefined ? {'^example-attribute': this.exampleAttribute } : {}),...((this.typeUnion) !== undefined ? {'^type-union': this.typeUnion } : {}),...((this.importedType) !== undefined ? {'.importedType': this.importedType } : {}),...((this.modelValue ?? this.value) !== undefined ? {'^value': this.modelValue ?? this.value } : {}),...((this.start) !== undefined ? {'^start': this.start } : {}),...((this.forcedDomProp) !== undefined ? {'.forcedDomProp': this.forcedDomProp } : {}),...((this.booleanAttribute) !== undefined && (this.booleanAttribute) !== false ? {'^boolean-attribute': this.booleanAttribute } : {}),'onExampleEvent': (event: Event) => this.$emit('example-event', event),'onInput': (event: Event) => {
           this.$emit('update:modelValue', (event.target as any).value);
           this.$emit('input', event);
         },'onInput:start': (event: Event) => {
@@ -165,7 +167,9 @@ export default defineComponent({
 
         start: {type: String as PropType<string>, default: undefined},
 
-        forcedDomProp: {type: String as PropType<string>, default: undefined}
+        forcedDomProp: {type: String as PropType<string>, default: undefined},
+
+        booleanAttribute: {type: Boolean as PropType<boolean>, default: undefined}
   },
   emits: {
 			

--- a/libs/wrapper-gen/src/generator/parseComponent.ts
+++ b/libs/wrapper-gen/src/generator/parseComponent.ts
@@ -92,6 +92,7 @@ export const parseComponent = (name: string): ComponentDef => {
 				forwardTo: {
 					type: 'attribute',
 					name: attribute.name || attribute.fieldName,
+					boolean: type.some((t) => t.text === 'boolean'),
 				},
 			};
 		} else {

--- a/libs/wrapper-gen/src/generator/renderComponent.ts
+++ b/libs/wrapper-gen/src/generator/renderComponent.ts
@@ -153,10 +153,22 @@ export const renderComponent = (
 						? `^${forwardTo.name}`
 						: `.${forwardTo.name}`;
 
+				// Vue 2 and 3 differ in how they handle boolean attributes
+				// Remove false attributes in Vue 3 to make it behave like Vue 2
+				const booleanFilter =
+					forwardTo.type === 'attribute' &&
+					forwardTo.boolean &&
+					syntax === 'vue3'
+						? ` && (${valueToUse}) !== false`
+						: '';
+
 				// Vue requires us to filter out undefined properties before passing them into the h function
-				return `...(${valueToUse} !== undefined ? {'${nameToUse}': ${valueToUse} } : {})`;
+				const filter = `(${valueToUse}) !== undefined${booleanFilter}`;
+
+				return `...(${filter} ? {'${nameToUse}': ${valueToUse} } : {})`;
 			})
 			.join(',');
+
 	const propsV3Src = renderProps(attributes, 'vue3');
 
 	const propsV2Src = renderProps(


### PR DESCRIPTION
Make Vue 3 behave like Vue 2 for boolean attributes. When `false`, attribute should be removed instead of set to `'false'`