### PR TITLE
fix(selectable box): screen-reader accessibility when box is clickable (VIV-000)

### DIFF
--- a/libs/components/src/lib/selectable-box/selectable-box.spec.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.spec.ts
@@ -434,6 +434,7 @@ describe('vwc-selectable-box', () => {
 
 			expect(control?.getAttribute('tabindex')).toBe(null);
 			expect(control?.getAttribute('aria-label')).toBe('Box 1');
+			expect(control?.getAttribute('aria-press')).toBe(null);
 		});
 
 		describe('radio', () => {
@@ -473,7 +474,7 @@ describe('vwc-selectable-box', () => {
 
 			it('should put the correct a11y attributes on the base element', async () => {
 				expect(baseElement?.getAttribute('aria-label')).toBe('Box 1');
-				expect(baseElement?.getAttribute('aria-pressed')).toBe(null);
+				expect(baseElement?.getAttribute('aria-pressed')).toBe('false');
 				expect(baseElement?.getAttribute('role')).toBe('button');
 				expect(baseElement?.getAttribute('tabindex')).toBe('0');
 			});
@@ -518,7 +519,7 @@ describe('vwc-selectable-box', () => {
 
 			it('should put the correct a11y attributes on the base element', async () => {
 				expect(baseElement?.getAttribute('aria-label')).toBe('Box 1');
-				expect(baseElement?.getAttribute('aria-pressed')).toBe(null);
+				expect(baseElement?.getAttribute('aria-pressed')).toBe('false');
 				expect(baseElement?.getAttribute('role')).toBe('button');
 				expect(baseElement?.getAttribute('tabindex')).toBe('0');
 			});

--- a/libs/components/src/lib/selectable-box/selectable-box.template.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.template.ts
@@ -83,8 +83,8 @@ export const SelectableBoxTemplate: (
 			class="${getClasses}"
 			tabindex="${(x) => (x.clickableBox || x.clickable ? '0' : null)}"
 			role="${(x) => (x.clickableBox || x.clickable ? 'button' : null)}"
-			aria-pressed="${(x) => (x.clickableBox || x.clickable) ? 
-				x.checked ? 'true' : 'false' : null }"
+			aria-pressed="${(x) =>
+				x.clickableBox || x.clickable ? (x.checked ? 'true' : 'false') : null}"
 			aria-label="${(x) =>
 				x.clickableBox || x.clickable ? x.ariaLabel : null}"
 			@keydown="${(x, c) => x._handleKeydown(c.event as KeyboardEvent)}"

--- a/libs/components/src/lib/selectable-box/selectable-box.template.ts
+++ b/libs/components/src/lib/selectable-box/selectable-box.template.ts
@@ -83,8 +83,8 @@ export const SelectableBoxTemplate: (
 			class="${getClasses}"
 			tabindex="${(x) => (x.clickableBox || x.clickable ? '0' : null)}"
 			role="${(x) => (x.clickableBox || x.clickable ? 'button' : null)}"
-			aria-pressed="${(x) =>
-				(x.clickableBox || x.clickable) && x.checked ? x.checked : null}"
+			aria-pressed="${(x) => (x.clickableBox || x.clickable) ? 
+				x.checked ? 'true' : 'false' : null }"
 			aria-label="${(x) =>
 				x.clickableBox || x.clickable ? x.ariaLabel : null}"
 			@keydown="${(x, c) => x._handleKeydown(c.event as KeyboardEvent)}"


### PR DESCRIPTION
When `clickable-box` is enabled, screen readers should announcement the control as a "toggle button".
This only happened when the box is checked. The reason is that the control had `aria-pressed="true"` set when it is checked but it is set to null when it is not checked, it should have been set to `false`.