### PR TITLE
fix(popup): add min-width to the popup-wrapper (VIV-000)

### DIFF
--- a/libs/components/src/lib/popup/popup.ts
+++ b/libs/components/src/lib/popup/popup.ts
@@ -61,6 +61,7 @@ export class Popup extends FoundationElement {
 					Object.assign(elements.floating.style, {
 						maxWidth: `${availableWidth}px`,
 						maxHeight: `${availableHeight}px`,
+						minWidth: `1px`
 					});
 				},
 			}),

--- a/libs/components/src/lib/popup/popup.ts
+++ b/libs/components/src/lib/popup/popup.ts
@@ -61,7 +61,7 @@ export class Popup extends FoundationElement {
 					Object.assign(elements.floating.style, {
 						maxWidth: `${availableWidth}px`,
 						maxHeight: `${availableHeight}px`,
-						minWidth: `1px`
+						minWidth: `1px`,
 					});
 				},
 			}),


### PR DESCRIPTION
To fix issues with max-width calculation when the popup is off-screen and needs to be flipped the other way