### PR TITLE
fix(dialog): prevent scroll to top when opened as Modal (VIV-2248)

### DIFF
--- a/libs/components/src/lib/dialog/dialog.scss
+++ b/libs/components/src/lib/dialog/dialog.scss
@@ -40,8 +40,6 @@ $dialog-space-size: 24px;
 	}
 
 	&.modal {
-		position: fixed;
-
 		// reason for box-shadow & hardcoded color - PR-1098
 		box-shadow: 0 4px 20px rgb(0 0 0 / 35%);
 		&::backdrop {

--- a/libs/components/src/lib/dialog/dialog.template.ts
+++ b/libs/components/src/lib/dialog/dialog.template.ts
@@ -56,7 +56,7 @@ export const DialogTemplate = (context: VividElementDefinitionContext) => {
 	const buttonTag = context.tagFor(Button);
 
 	return html<Dialog>`
-	<${elevationTag} dp="8">
+	<${elevationTag} dp="8" no-position>
 		<dialog class="${getClasses}"
 				@keydown="${(x, c) => x._onKeyDown(c.event as KeyboardEvent)}"
 				@cancel="${(_, c) => c.event.preventDefault()}"

--- a/libs/components/src/lib/elevation/README.md
+++ b/libs/components/src/lib/elevation/README.md
@@ -76,3 +76,12 @@ Use the `dp` attribute to change the elevation's level in Density-Independent Pi
 	<div class="card">This is the content inside the elevation with DP 24</div>
 </vwc-elevation>
 ```
+
+### No Shadow
+
+Use the no-shadow attribute to toggle off the elevation's drop shadow.
+
+### No Position
+
+When there's no need for `position:relative` set on the slotted content. Used in Dialog - caused issues with positioning and scroll to top.  
+This is for use only if the slotted content contain position absolute or fixed. Otherwise, the `:before` element will be mispositioned.

--- a/libs/components/src/lib/elevation/elevation.scss
+++ b/libs/components/src/lib/elevation/elevation.scss
@@ -18,7 +18,6 @@ $dps: 0 2 4 8 12 16 24;
 	}
 
 	::slotted(*) {
-		position: relative;
 		isolation: isolate;
 
 		&::before {
@@ -35,6 +34,12 @@ $dps: 0 2 4 8 12 16 24;
 			inset-block-start: 0;
 			inset-inline-start: 0;
 			transition: background-color 0.15s linear, filter 0.15s linear;
+		}
+	}
+
+	&:not(.no-position) {
+		::slotted(*) {
+			position: relative;
 		}
 	}
 

--- a/libs/components/src/lib/elevation/elevation.template.ts
+++ b/libs/components/src/lib/elevation/elevation.template.ts
@@ -2,11 +2,12 @@ import { html } from '@microsoft/fast-element';
 import { classNames } from '@microsoft/fast-web-utilities';
 import type { Elevation } from './elevation';
 
-const getClasses = ({ dp, noShadow }: Elevation) =>
+const getClasses = ({ dp, noShadow, noPosition }: Elevation) =>
 	classNames(
 		'control',
 		[`dp-${dp}`, Boolean(dp)],
-		['no-shadow', Boolean(noShadow)]
+		['no-shadow', Boolean(noShadow)],
+		['no-position', Boolean(noPosition)]
 	);
 
 export const elevationTemplate = html<Elevation>` <div

--- a/libs/components/src/lib/elevation/elevation.ts
+++ b/libs/components/src/lib/elevation/elevation.ts
@@ -21,4 +21,5 @@ export class Elevation extends VividElement {
 	 * HTML Attribute: boolean
 	 */
 	@attr({ attribute: 'no-shadow', mode: 'boolean' }) noShadow?: boolean;
+	@attr({ attribute: 'no-position', mode: 'boolean' }) noPosition?: boolean;
 }


### PR DESCRIPTION
Also we had a but that the dialog that is not modal was positioned relative and not absolute.
This is also fixed now.
