### PR TITLE
fix(radio): radio required validation sync with spec (VIV-2265)

### DIFF
--- a/libs/components/src/lib/radio/radio.form-associated.ts
+++ b/libs/components/src/lib/radio/radio.form-associated.ts
@@ -15,7 +15,7 @@ export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
 		if (siblings) {
 			return Array.from(siblings) as unknown as _Radio[];
 		}
-		return []; 
+		return [];
 	}
 
 	#validateValueMissingWithSiblings = (): void => {
@@ -28,8 +28,8 @@ export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
 		}
 	};
 
-	#syncSiblingsRequiredValidationStatus = (force = false): void => {
-		if (this.elementInternals && (!this.validity.valueMissing || force)) {
+	#syncSiblingsRequiredValidationStatus = (): void => {
+		if (this.elementInternals && (!this.validity.valueMissing)) {
 			const siblings = this.#radioSiblings;
 			if (siblings && siblings.length > 1) {
 				siblings.forEach((x: _Radio) => {
@@ -39,12 +39,12 @@ export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
 		}
 	};
 
-	override validate = (anchor?: HTMLElement): void => {		
+	override validate = (anchor?: HTMLElement): void => {
 		super.validate(anchor);
 		if (this.validity.valueMissing) {
 			this.#validateValueMissingWithSiblings();
 		} else {
-			this.#syncSiblingsRequiredValidationStatus(true);
-		} 
-	}
+			this.#syncSiblingsRequiredValidationStatus();
+		}
+	};
 }

--- a/libs/components/src/lib/radio/radio.form-associated.ts
+++ b/libs/components/src/lib/radio/radio.form-associated.ts
@@ -29,7 +29,7 @@ export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
 	};
 
 	#syncSiblingsRequiredValidationStatus = (): void => {
-		if (this.elementInternals && (!this.validity.valueMissing)) {
+		if (this.elementInternals && !this.validity.valueMissing) {
 			const siblings = this.#radioSiblings;
 			if (siblings && siblings.length > 1) {
 				siblings.forEach((x: _Radio) => {

--- a/libs/components/src/lib/radio/radio.form-associated.ts
+++ b/libs/components/src/lib/radio/radio.form-associated.ts
@@ -7,4 +7,44 @@ interface _Radio extends CheckableFormAssociated {}
 
 export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
 	proxy = document.createElement('input');
+
+	get #radioSiblings(): _Radio[] {
+		const siblings = this.parentElement?.querySelectorAll(
+			`${this.tagName.toLocaleLowerCase()}[name="${this.name}"]`
+		);
+		if (siblings) {
+			return Array.from(siblings) as unknown as _Radio[];
+		}
+		return []; 
+	}
+
+	#validateValueMissingWithSiblings = (): void => {
+		const siblings = this.#radioSiblings;
+		if (siblings && siblings.length > 1) {
+			const isSiblingChecked = siblings.some((x: _Radio) => x.checked);
+			if (isSiblingChecked) {
+				this.setValidity({ valueMissing: false });
+			}
+		}
+	};
+
+	#syncSiblingsRequiredValidationStatus = (force = false): void => {
+		if (this.elementInternals && (!this.validity.valueMissing || force)) {
+			const siblings = this.#radioSiblings;
+			if (siblings && siblings.length > 1) {
+				siblings.forEach((x: _Radio) => {
+					x.elementInternals!.setValidity({ valueMissing: false });
+				});
+			}
+		}
+	};
+
+	override validate = (anchor?: HTMLElement): void => {		
+		super.validate(anchor);
+		if (this.validity.valueMissing) {
+			this.#validateValueMissingWithSiblings();
+		} else {
+			this.#syncSiblingsRequiredValidationStatus(true);
+		} 
+	}
 }

--- a/libs/components/src/lib/radio/radio.spec.ts
+++ b/libs/components/src/lib/radio/radio.spec.ts
@@ -299,12 +299,12 @@ describe('vwc-radio', () => {
 
 			element.name = sibling.name;
 			await elementUpdated(element);
-			
+
 			expect(valueWhenNameIsDifferent).toBe(true);
 			expect(element.validity.valueMissing).toBe(false);
-		}); 
+		});
 	});
-	
+
 	describe('change', () => {
 		it('should be fired when a user toggles the radio', async () => {
 			const spy = jest.fn();

--- a/libs/components/src/lib/radio/radio.spec.ts
+++ b/libs/components/src/lib/radio/radio.spec.ts
@@ -277,7 +277,34 @@ describe('vwc-radio', () => {
 
 			expect(element.validity.valueMissing).toBe(false);
 		});
+
+		it('should sync values when name changes to that of siblings', async () => {
+			await import('element-internals-polyfill');
+
+			mockFormAssociated();
+			mockElementInternals();
+
+			const sibling = document.createElement(COMPONENT_TAG) as Radio;
+			sibling.name = 'not-test';
+			element.name = 'test';
+			sibling.required = element.required = true;
+			sibling.checked = true;
+
+			await elementUpdated(element);
+			element.parentElement?.appendChild(sibling);
+
+			await elementUpdated(element);
+
+			const valueWhenNameIsDifferent = element.validity.valueMissing;
+
+			element.name = sibling.name;
+			await elementUpdated(element);
+			
+			expect(valueWhenNameIsDifferent).toBe(true);
+			expect(element.validity.valueMissing).toBe(false);
+		}); 
 	});
+	
 	describe('change', () => {
 		it('should be fired when a user toggles the radio', async () => {
 			const spy = jest.fn();

--- a/libs/components/src/lib/radio/radio.spec.ts
+++ b/libs/components/src/lib/radio/radio.spec.ts
@@ -143,6 +143,36 @@ describe('vwc-radio', () => {
 		});
 	});
 
+	describe('required', () => {
+		it('should reflect required attribute', async () => {
+			element.required = true;
+			await elementUpdated(element);
+			expect(element.hasAttribute('required')).toBe(true);
+		});
+
+		it('should invalidate the element when required and not selected', async () => {
+			element.required = true;
+			await elementUpdated(element);
+			element.checkValidity();
+			expect(element.validity.valueMissing).toBe(true);
+		});
+
+		it('should set the name attribute on the proxy element so that elementals validation works', async () => {
+			element.name = 'test';
+			await elementUpdated(element);
+			expect(element.proxy.name).toBe('test');
+		});
+
+		it('should remove the proxy name attribute if removed from the element', async () => {
+			element.name = 'test';
+			await elementUpdated(element);
+
+			element.removeAttribute('name');
+			await elementUpdated(element);
+
+			expect(element.proxy.getAttribute('name')).toBeNull();
+		});
+	});
 	describe('change', () => {
 		it('should be fired when a user toggles the radio', async () => {
 			const spy = jest.fn();

--- a/libs/components/src/lib/radio/radio.ts
+++ b/libs/components/src/lib/radio/radio.ts
@@ -1,5 +1,6 @@
 import {
 	attr,
+	DOM,
 	observable,
 	type SyntheticViewTemplate,
 } from '@microsoft/fast-element';
@@ -134,7 +135,11 @@ export class Radio extends FormAssociatedRadio {
 		next !== null
 			? this.proxy.setAttribute('name', this.name)
 			: this.proxy.removeAttribute('name');
-	}
+		DOM.queueUpdate(this.validate);
+		// DOM.queueUpdate(() => {
+		// 	this.#validateValueMissingWithSiblings();
+		// }); 
+	} 
 	/**
 	 * @internal
 	 */
@@ -163,7 +168,7 @@ export class Radio extends FormAssociatedRadio {
 			}
 		}
 
-		this.#validateValueMissingWithSiblings();
+		// this.#validateValueMissingWithSiblings();
 	}
 
 	private isInsideRadioGroup(): boolean {
@@ -197,42 +202,42 @@ export class Radio extends FormAssociatedRadio {
 		}
 	}
 
-	/**
-	 * @internal
-	 */
-	override checkedChanged = (previous: boolean, next: boolean): void => {
-		super.checkedChanged(previous, next);
-		this.#syncSiblingsRequiredValidationStatus();
-	};
+	// /**
+	//  * @internal
+	//  */
+	// override checkedChanged = (previous: boolean, next: boolean): void => {
+	// 	super.checkedChanged(previous, next);
+	// 	this.#syncSiblingsRequiredValidationStatus();
+	// };
 
-	get #radioSiblings(): Radio[] {
-		const siblings = this.parentElement?.querySelectorAll(
-			`${this.tagName.toLocaleLowerCase()}[name="${this.name}"]`
-		);
-		if (siblings) {
-			return Array.from(siblings) as unknown as Radio[];
-		}
-		return [];
-	}
+	// get #radioSiblings(): Radio[] {
+	// 	const siblings = this.parentElement?.querySelectorAll(
+	// 		`${this.tagName.toLocaleLowerCase()}[name="${this.name}"]`
+	// 	);
+	// 	if (siblings) {
+	// 		return Array.from(siblings) as unknown as Radio[];
+	// 	}
+	// 	return []; 
+	// }
 
-	#syncSiblingsRequiredValidationStatus = (force = false): void => {
-		if (this.elementInternals && (!this.validity.valueMissing || force)) {
-			const siblings = this.#radioSiblings;
-			if (siblings && siblings.length > 1) {
-				siblings.forEach((x: Radio) => {
-					x.elementInternals!.setValidity({ valueMissing: false });
-				});
-			}
-		}
-	};
+	// #syncSiblingsRequiredValidationStatus = (force = false): void => {
+	// 	if (this.elementInternals && (!this.validity.valueMissing || force)) {
+	// 		const siblings = this.#radioSiblings;
+	// 		if (siblings && siblings.length > 1) {
+	// 			siblings.forEach((x: Radio) => {
+	// 				x.elementInternals!.setValidity({ valueMissing: false });
+	// 			});
+	// 		}
+	// 	}
+	// };
 
-	#validateValueMissingWithSiblings = (): void => {
-		const siblings = this.#radioSiblings;
-		if (siblings && siblings.length > 1) {
-			const isSiblingChecked = siblings.some((x: Radio) => x.checked);
-			if (isSiblingChecked) {
-				this.#syncSiblingsRequiredValidationStatus(true);
-			}
-		}
-	};
+	// #validateValueMissingWithSiblings = (): void => {
+	// 	const siblings = this.#radioSiblings;
+	// 	if (siblings && siblings.length > 1) {
+	// 		const isSiblingChecked = siblings.some((x: Radio) => x.checked);
+	// 		if (isSiblingChecked) {
+	// 			this.#syncSiblingsRequiredValidationStatus(true);
+	// 		}
+	// 	}
+	// };
 }

--- a/libs/components/src/lib/radio/radio.ts
+++ b/libs/components/src/lib/radio/radio.ts
@@ -143,7 +143,7 @@ export class Radio extends FormAssociatedRadio {
 	 */
 	override connectedCallback(): void {
 		super.connectedCallback();
-		this.validate();
+		DOM.queueUpdate(this.validate);
 
 		if (
 			this.parentElement!.getAttribute('role') !== 'radiogroup' &&
@@ -165,8 +165,6 @@ export class Radio extends FormAssociatedRadio {
 				}
 			}
 		}
-
-		// this.#validateValueMissingWithSiblings();
 	}
 
 	private isInsideRadioGroup(): boolean {

--- a/libs/components/src/lib/radio/radio.ts
+++ b/libs/components/src/lib/radio/radio.ts
@@ -135,11 +135,9 @@ export class Radio extends FormAssociatedRadio {
 		next !== null
 			? this.proxy.setAttribute('name', this.name)
 			: this.proxy.removeAttribute('name');
+
 		DOM.queueUpdate(this.validate);
-		// DOM.queueUpdate(() => {
-		// 	this.#validateValueMissingWithSiblings();
-		// }); 
-	} 
+	}
 	/**
 	 * @internal
 	 */
@@ -201,43 +199,4 @@ export class Radio extends FormAssociatedRadio {
 			this.checked = true;
 		}
 	}
-
-	// /**
-	//  * @internal
-	//  */
-	// override checkedChanged = (previous: boolean, next: boolean): void => {
-	// 	super.checkedChanged(previous, next);
-	// 	this.#syncSiblingsRequiredValidationStatus();
-	// };
-
-	// get #radioSiblings(): Radio[] {
-	// 	const siblings = this.parentElement?.querySelectorAll(
-	// 		`${this.tagName.toLocaleLowerCase()}[name="${this.name}"]`
-	// 	);
-	// 	if (siblings) {
-	// 		return Array.from(siblings) as unknown as Radio[];
-	// 	}
-	// 	return []; 
-	// }
-
-	// #syncSiblingsRequiredValidationStatus = (force = false): void => {
-	// 	if (this.elementInternals && (!this.validity.valueMissing || force)) {
-	// 		const siblings = this.#radioSiblings;
-	// 		if (siblings && siblings.length > 1) {
-	// 			siblings.forEach((x: Radio) => {
-	// 				x.elementInternals!.setValidity({ valueMissing: false });
-	// 			});
-	// 		}
-	// 	}
-	// };
-
-	// #validateValueMissingWithSiblings = (): void => {
-	// 	const siblings = this.#radioSiblings;
-	// 	if (siblings && siblings.length > 1) {
-	// 		const isSiblingChecked = siblings.some((x: Radio) => x.checked);
-	// 		if (isSiblingChecked) {
-	// 			this.#syncSiblingsRequiredValidationStatus(true);
-	// 		}
-	// 	}
-	// };
 }

--- a/libs/components/src/lib/radio/radio.ts
+++ b/libs/components/src/lib/radio/radio.ts
@@ -86,7 +86,7 @@ export class Radio extends FormAssociatedRadio {
 	/**
 	 * The name of the radio. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname | name attribute} for more info.
 	 */
-	@observable
+	@attr
 	override name!: string;
 
 	/**
@@ -121,8 +121,17 @@ export class Radio extends FormAssociatedRadio {
 	constructor() {
 		super();
 		this.proxy.setAttribute('type', 'radio');
+		this.proxy.setAttribute('name', this.name);
 	}
 
+
+	/**
+	 * @internal
+	 */
+	override nameChanged(previous: string, next: string): void {
+		super.nameChanged ? super.nameChanged(previous, next) : null;
+		next !== null ? this.proxy.setAttribute('name', this.name) : this.proxy.removeAttribute('name');
+	}
 	/**
 	 * @internal
 	 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -19373,7 +19373,8 @@
 			"version": "1.3.12",
 			"resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.3.12.tgz",
 			"integrity": "sha512-KW1k+cMGwXlx3X9nqhgmuElAfR/c/ccFt0pG4KpwK++Mx9Y+mPExxJW+jgQnqux/NQrJejgOxxg4Naf3f6y67Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/eleventy-plugin-nesting-toc": {
 			"version": "1.3.0",


### PR DESCRIPTION
The spec says the following:
- Radio with a `name` property should be validated for required
- Radio with a `name` in a group should be validated for required with all siblings of the same `name` such that if one of them is checked, required is satisfied and then `validity.valueMissing` should be false.