### PR TITLE
chore(nx-vivid): update the component generator template (VIV-000)

### DIFF
--- a/libs/nx-vivid/src/generators/component/files/__fileName__.scss__tmpl__
+++ b/libs/nx-vivid/src/generators/component/files/__fileName__.scss__tmpl__
@@ -1,0 +1,1 @@
+// Style for <%= name %>

--- a/libs/nx-vivid/src/generators/component/files/__fileName__.spec.ts__tmpl__
+++ b/libs/nx-vivid/src/generators/component/files/__fileName__.spec.ts__tmpl__
@@ -13,7 +13,6 @@ describe( 'vwc-<%= name %>', () => {
 
 	describe('basic', () => {
 		it('should be initialized as a vwc-<%= name %>', async () => {
-			expect(<%= camelCasedName %>Definition()).toBeInstanceOf(FoundationElementRegistry);
 			expect(element).toBeInstanceOf(<%= className %>);
 		});
 

--- a/libs/nx-vivid/src/generators/component/files/__fileName__.template.ts__tmpl__
+++ b/libs/nx-vivid/src/generators/component/files/__fileName__.template.ts__tmpl__
@@ -1,8 +1,8 @@
 import { html } from '@microsoft/fast-element';
 import type { ViewTemplate } from '@microsoft/fast-element';
-import type { ElementDefinitionContext, FoundationElementDefinition } from '@microsoft/fast-foundation';
 import { classNames } from '@microsoft/fast-web-utilities';
-import type { <%= className %> } from './<%= fileName %>';
+import type { VividElementDefinitionContext } from '../../shared/design-system/defineVividComponent';
+import { <%= className %> } from './<%= fileName %>';
 
 const getClasses = (_: <%= className %>) =>
 	classNames(
@@ -16,9 +16,8 @@ const getClasses = (_: <%= className %>) =>
  * @public
  */
 export const <%= className %>Template: (
-	context: ElementDefinitionContext,
-	definition: FoundationElementDefinition
-) => ViewTemplate<<%= className %>> = (context: ElementDefinitionContext) => html` <span
+	context: VividElementDefinitionContext
+) => ViewTemplate<<%= className %>> = (context: VividElementDefinitionContext) => html` <span
   class="${getClasses}"
->${context.name}
+>${context.tagFor(<%= className %>)}
 </span>`;

--- a/libs/nx-vivid/src/generators/component/files/definition.ts__tmpl__
+++ b/libs/nx-vivid/src/generators/component/files/definition.ts__tmpl__
@@ -1,24 +1,26 @@
-import type { FoundationElementDefinition } from '@microsoft/fast-foundation';
-import { registerFactory } from '../../shared/design-system';
+import { createRegisterFunction } from '../../shared/design-system/createRegisterFunction';
+import { defineVividComponent } from '../../shared/design-system/defineVividComponent';
 import styles from './<%= fileName %>.scss?inline';
 
 import { <%= className %> } from './<%= fileName %>';
 import { <%= className %>Template as template } from './<%= fileName %>.template';
 
-export const <%= camelCasedName %>Definition = <%= className %>.compose<FoundationElementDefinition>({
-	baseName: '<%= name %>',
-	template: template as any,
-	styles,
-});
-
-/**
- * @internal
- */
-export const <%= camelCasedName %>Registries = [<%= camelCasedName %>Definition()];
+export const <%= camelCasedName %>Definition = defineVividComponent(
+	'<%= name %>',
+	<%= className %>,
+	template,
+	[],
+	{
+		styles,
+		shadowOptions: {
+			delegatesFocus: true,
+		},
+	}
+);
 
 /**
  * Registers the <%= name %> element with the design system.
  *
  * @param prefix - the prefix to use for the component name
  */
-export const register<%= className %> = registerFactory(<%= camelCasedName %>Registries);
+export const register<%= className %> = createRegisterFunction(<%= camelCasedName %>Definition);


### PR DESCRIPTION
Now passes all tests and lintings (except e2e, which needs to generate snapshots)