### PR TITLE
feat(components): expose version number (VIV-000)

### DIFF
--- a/libs/components/src/shared/foundation/vivid-element/vivid-element.spec.ts
+++ b/libs/components/src/shared/foundation/vivid-element/vivid-element.spec.ts
@@ -1,0 +1,14 @@
+import { VividElement } from './vivid-element';
+
+describe('VividElement', () => {
+	describe('VIVID_VERSION', () => {
+		it('should expose the current version of the Vivid library', () => {
+			const majorVersion = parseInt(
+				VividElement.VIVID_VERSION.split('.')[0],
+				10
+			);
+
+			expect(majorVersion).toBeGreaterThanOrEqual(3);
+		});
+	});
+});

--- a/libs/components/src/shared/foundation/vivid-element/vivid-element.ts
+++ b/libs/components/src/shared/foundation/vivid-element/vivid-element.ts
@@ -3,4 +3,10 @@ import { FASTElement } from '@microsoft/fast-element';
 /**
  * Base class for all Vivid elements.
  */
-export class VividElement extends FASTElement {}
+export class VividElement extends FASTElement {
+	/**
+	 * The current version of the Vivid library, which is useful for debugging.
+	 * It can be accessed from any Vivid element via `<el>.constructor.VIVID_VERSION`.
+	 */
+	static VIVID_VERSION = __PACKAGE_VERSION__;
+}

--- a/libs/components/src/types/vite.d.ts
+++ b/libs/components/src/types/vite.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const __PACKAGE_VERSION__: string;

--- a/libs/components/vite.config.ts
+++ b/libs/components/vite.config.ts
@@ -56,6 +56,10 @@ function generateRollupInput() {
 
 const input = generateRollupInput();
 
+const packageVersion = JSON.parse(
+	fs.readFileSync('package.json', 'utf-8')
+).version;
+
 const isWatchMode = process.env.WATCH === 'true';
 const isCI = process.env['CI'] === 'true';
 const isA11y = process.env['A11Y'] === 'true';
@@ -148,6 +152,9 @@ export default defineConfig(() => {
 						exclude: ['**/*.md'],
 				  }
 				: null,
+		},
+		define: {
+			__PACKAGE_VERSION__: JSON.stringify(packageVersion),
 		},
 		css: {
 			preprocessorOptions: {


### PR DESCRIPTION
Allows checking the Vivid version of components. Why? Because otherwise it is practically impossible to figure out the version that ends up being used in a page