### PR TITLE
chore(rich-text-editor): fix selection reset on user selection (VIV-2435)

### DIFF
--- a/libs/components/src/lib/rich-text-editor/facades/vivid-prose-mirror.facade.ts
+++ b/libs/components/src/lib/rich-text-editor/facades/vivid-prose-mirror.facade.ts
@@ -55,7 +55,7 @@ export class ProseMirrorFacade {
 		this.#dispatchEvent('input');
 	};
 
-	#handleBlueEvent = () => {
+	#handleChangeEvent = () => {
 		if (!this.#userContentChange) {
 			return;
 		}
@@ -79,7 +79,7 @@ export class ProseMirrorFacade {
 		});
 		this.#view = new EditorView(element, { state });
 		this.#view.dom.addEventListener('input', this.#handleInputEvent);
-		this.#view.dom.addEventListener('blur', this.#handleBlueEvent);
+		this.#view.dom.addEventListener('blur', this.#handleChangeEvent);
 	}
 
 	replaceContent(content: string) {

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
@@ -322,6 +322,7 @@ describe('vwc-rich-text-editor', () => {
 			moveMarkerToPosition(5);
 			await elementUpdated(element);
 		});
+
 		it('should set the event to bubble and composed', async () => {
 			expect(getEventObject().bubbles).toBe(true);
 			expect(getEventObject().composed).toBe(true);
@@ -329,6 +330,16 @@ describe('vwc-rich-text-editor', () => {
 
 		it('should fire the selection-changed event when selection changes', async () => {
 			expect(selectionChangedListenerCallback).toHaveBeenCalledOnce();
+		});
+
+		it('should prevent call to facade select when updating values from the event', async () => {
+			editorFacadeSelectSpy = spyOnOriginalFacadeSelect();
+			editorFacadeSelectSpy.mockReset();
+			selectInEditor(4, 5);
+			await elementUpdated(element);
+			selectInEditor(3, 5);
+			await elementUpdated(element);
+			expect(editorFacadeSelectSpy).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.ts
@@ -37,6 +37,9 @@ export class RichTextEditor extends VividElement {
 	@attr({ converter: nullableNumberConverter, attribute: 'selection-start' })
 	selectionStart: number | null = null;
 	selectionStartChanged() {
+		if (this.#selectionChangedByUser) {
+			return;
+		}
 		if (
 			!this.selectionStart ||
 			(this.selectionEnd && this.selectionStart > this.selectionEnd)
@@ -62,6 +65,10 @@ export class RichTextEditor extends VividElement {
 	@attr({ converter: nullableNumberConverter, attribute: 'selection-end' })
 	selectionEnd: number | null = null;
 	selectionEndChanged() {
+		if (this.#selectionChangedByUser) {
+			this.#selectionChangedByUser = false;
+			return;
+		}
 		if (this.selectionEnd && !this.selectionStart) {
 			this.selectionStart = 1;
 		}
@@ -73,11 +80,14 @@ export class RichTextEditor extends VividElement {
 		super();
 	}
 
+	#selectionChangedByUser = false;
+
 	#handleSelectionChange = () => {
 		if (!this.#editor!.selection()) {
 			return;
 		}
 		const { start, end } = this.#editor!.selection();
+		this.#selectionChangedByUser = true;
 		this.selectionStart = start;
 		this.selectionEnd = end as number;
 		this.$emit('selection-changed');


### PR DESCRIPTION
Should now allow to select and sync backward selection (Shift + Arrowleft keys)