### PR TITLE
chore(rich-text-editor): text decoration buttons active in the menubar (VIV-2370)

### DIFF
--- a/libs/components/metadata.json
+++ b/libs/components/metadata.json
@@ -5759,6 +5759,11 @@
 					"returnType": "unknown"
 				},
 				{
+					"name": "setSelectionDecoration",
+					"args": [{ "name": "decoration", "type": "string" }],
+					"returnType": "unknown"
+				},
+				{
 					"name": "setTextSize",
 					"args": [{ "name": "size", "type": "'title' | 'subtitle' | 'body'" }],
 					"returnType": "unknown"

--- a/libs/components/src/lib/rich-text-editor/facades/prose-mirror-vivid.schema.ts
+++ b/libs/components/src/lib/rich-text-editor/facades/prose-mirror-vivid.schema.ts
@@ -1,7 +1,6 @@
 import { schema as basicSchema } from 'prosemirror-schema-basic';
 import { Schema } from 'prosemirror-model';
 
-// Define custom marks
 const customMarks = {
 	u: {
 		parseDOM: [{ tag: 'u' }],

--- a/libs/components/src/lib/rich-text-editor/facades/vivid-prose-mirror.facade.spec.ts
+++ b/libs/components/src/lib/rich-text-editor/facades/vivid-prose-mirror.facade.spec.ts
@@ -425,7 +425,6 @@ describe('ProseMirrorFacade', () => {
 			const event = new KeyboardEvent('keydown', { key: 'Enter' });
 			getOutputElement(element).dispatchEvent(event);
 
-			// Verify the expected behavior for Enter key press
 			expect(facadeInstance.selection()).toEqual({
 				start: content.length + NEWLINE_POSITION_VALUE,
 				end: content.length + NEWLINE_POSITION_VALUE,

--- a/libs/components/src/lib/rich-text-editor/menubar/definition.ts
+++ b/libs/components/src/lib/rich-text-editor/menubar/definition.ts
@@ -4,6 +4,7 @@ import {
 	buttonDefinition,
 	menuDefinition,
 	menuItemDefinition,
+	dividerDefinition,
 } from '../../components';
 import styles from './menubar.scss?inline';
 
@@ -14,7 +15,7 @@ export const menuBarDefinition = defineVividComponent(
 	'menubar',
 	MenuBar,
 	template,
-	[buttonDefinition, menuDefinition, menuItemDefinition],
+	[buttonDefinition, menuDefinition, menuItemDefinition, dividerDefinition],
 	{
 		styles,
 		shadowOptions: {

--- a/libs/components/src/lib/rich-text-editor/menubar/definition.ts
+++ b/libs/components/src/lib/rich-text-editor/menubar/definition.ts
@@ -2,9 +2,9 @@ import { createRegisterFunction } from '../../../shared/design-system/createRegi
 import { defineVividComponent } from '../../../shared/design-system/defineVividComponent';
 import {
 	buttonDefinition,
+	dividerDefinition,
 	menuDefinition,
 	menuItemDefinition,
-	dividerDefinition,
 } from '../../components';
 import styles from './menubar.scss?inline';
 

--- a/libs/components/src/lib/rich-text-editor/menubar/menubar.scss
+++ b/libs/components/src/lib/rich-text-editor/menubar/menubar.scss
@@ -24,4 +24,8 @@
 .body {
 	--_text-primary-custom-size: var(#{constants.$vvd-typography-base});
 }
+
+.divider {
+	align-self: stretch;
+}
 /* stylelint-enable */

--- a/libs/components/src/lib/rich-text-editor/menubar/menubar.spec.ts
+++ b/libs/components/src/lib/rich-text-editor/menubar/menubar.spec.ts
@@ -182,7 +182,7 @@ describe('menuBar', () => {
 				element.addEventListener('text-decoration-selected', spy);
 				const listOfDecorations = [
 					'bold',
-					'italic',
+					'italics',
 					'underline',
 					'strikethrough',
 					'monospace',

--- a/libs/components/src/lib/rich-text-editor/menubar/menubar.template.ts
+++ b/libs/components/src/lib/rich-text-editor/menubar/menubar.template.ts
@@ -25,7 +25,7 @@ const TEXT_DECORATION_ITEMS = [
 	{
 		text: 'Italic',
 		icon: 'italic-line',
-		value: 'italic',
+		value: 'italics',
 	},
 	{
 		text: 'Underline',

--- a/libs/components/src/lib/rich-text-editor/menubar/menubar.template.ts
+++ b/libs/components/src/lib/rich-text-editor/menubar/menubar.template.ts
@@ -5,6 +5,7 @@ import type { VividElementDefinitionContext } from '../../../shared/design-syste
 import { Button } from '../../button/button';
 import { Menu } from '../../menu/menu';
 import { MenuItem } from '../../menu-item/menu-item';
+import { Divider } from '../../divider/divider';
 import { MenuBar } from './menubar.js';
 
 function notifyMenuBarChange(
@@ -100,7 +101,9 @@ const MENU_BAR_ITEMS: {
 	},
 	textDecoration: function (context) {
 		const buttonTag = context.tagFor(Button);
+		const dividerTag = context.tagFor(Divider);
 		return html`
+			<${dividerTag} class="divider" orientation="vertical"></${dividerTag}>
 			${repeat(
 				(_) => TEXT_DECORATION_ITEMS,
 				html`
@@ -119,6 +122,7 @@ const MENU_BAR_ITEMS: {
 					></${buttonTag}>
 				`
 			)}
+			<${dividerTag} class="divider" orientation="vertical"></${dividerTag}>
 		`;
 	},
 };

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
@@ -334,6 +334,15 @@ describe('vwc-rich-text-editor', () => {
 	});
 
 	describe('setSelectionDecoration()', () => {
+		it('should gracefully fail with a warning when given an invalid decoration value', async () => {
+			const consoleWarnSpy = vi.spyOn(console, 'warn');
+
+			(element.setSelectionDecoration as any)('unsupported-decoration');
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'Invalid decoration: unsupported-decoration'
+			);
+		});
+
 		it('should call facade setSelectionDecoration with the decoration parameter', async () => {
 			const setSelectionDecorationSpy = vi.spyOn(
 				EditorFacade.prototype,

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.spec.ts
@@ -37,6 +37,7 @@ describe('vwc-rich-text-editor', () => {
 	let editorFacadeSelectSpy: MockInstance<
 		(position?: RichTextEditorSelection) => RichTextEditorSelection
 	>;
+
 	let element: RichTextEditor;
 
 	beforeEach(async () => {
@@ -279,7 +280,7 @@ describe('vwc-rich-text-editor', () => {
 		});
 	});
 
-	describe('setTextSize', () => {
+	describe('setTextSize()', () => {
 		it('should gracefully fail with a warning when given an invalid size', async () => {
 			const consoleWarnSpy = vi.spyOn(console, 'warn');
 
@@ -329,6 +330,18 @@ describe('vwc-rich-text-editor', () => {
 			await elementUpdated(element);
 
 			expect(element.value).toEqual('<p>123456789</p><p>abcdefghi</p>');
+		});
+	});
+
+	describe('setSelectionDecoration()', () => {
+		it('should call facade setSelectionDecoration with the decoration parameter', async () => {
+			const setSelectionDecorationSpy = vi.spyOn(
+				EditorFacade.prototype,
+				'setSelectionDecoration'
+			);
+			const decoration = 'bold';
+			element.setSelectionDecoration(decoration);
+			expect(setSelectionDecorationSpy).toHaveBeenCalledWith(decoration);
 		});
 	});
 
@@ -449,6 +462,21 @@ describe('vwc-rich-text-editor', () => {
 
 			menuBar.dispatchEvent(
 				new CustomEvent('text-size-selected', { detail: newTextSize })
+			);
+
+			expect(setTextSizeSpy).toHaveBeenCalledWith(newTextSize);
+		});
+
+		it('should change text decoration on `text-decoration-selected` event from menubar', async () => {
+			const newTextSize = 'bold';
+			const setTextSizeSpy = vi.spyOn(element, 'setSelectionDecoration');
+			const menuBar = document.createElement('vwc-menubar');
+			menuBar.slot = 'menu-bar';
+			element.appendChild(menuBar);
+			await elementUpdated(element);
+
+			menuBar.dispatchEvent(
+				new CustomEvent('text-decoration-selected', { detail: newTextSize })
 			);
 
 			expect(setTextSizeSpy).toHaveBeenCalledWith(newTextSize);

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
@@ -33,9 +33,9 @@ function handleMenuBarSlotChange(
 	);
 	assignedElements.forEach((element) => {
 		if (element === menuBar) {
-			(element as HTMLElement).style.removeProperty('display'); // Remove inline display style
+			(element as HTMLElement).style.removeProperty('display');
 		} else {
-			(element as HTMLElement).style.display = 'none'; // Set display to 'none'
+			(element as HTMLElement).style.display = 'none';
 		}
 	});
 	if (menuBar) {

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
@@ -15,6 +15,13 @@ function textSizeSelectedHandler(
 	this.setTextSize(event.detail as RichTextEditorTextSizes);
 }
 
+function selectionDecorationSelectedHandler(
+	this: RichTextEditor,
+	event: CustomEvent<string>
+) {
+	this.setSelectionDecoration(event.detail as RichTextEditorTextSizes);
+}
+
 function handleMenuBarSlotChange(
 	richTextEditor: RichTextEditor,
 	{ event }: ExecutionContext
@@ -32,6 +39,10 @@ function handleMenuBarSlotChange(
 		menuBar.addEventListener(
 			'text-size-selected',
 			textSizeSelectedHandler.bind(richTextEditor) as EventListener
+		);
+		menuBar.addEventListener(
+			'text-decoration-selected',
+			selectionDecorationSelectedHandler.bind(richTextEditor) as EventListener
 		);
 	}
 }

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
@@ -33,10 +33,10 @@ function handleMenuBarSlotChange(
 	);
 	assignedElements.forEach((element) => {
 		if (element === menuBar) {
-            (element as HTMLElement).style.removeProperty('display'); // Remove inline display style
-        } else {
-            (element as HTMLElement).style.display = 'none'; // Set display to 'none'
-        }
+			(element as HTMLElement).style.removeProperty('display'); // Remove inline display style
+		} else {
+			(element as HTMLElement).style.display = 'none'; // Set display to 'none'
+		}
 	});
 	if (menuBar) {
 		menuBar.addEventListener(

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.template.ts
@@ -32,8 +32,11 @@ function handleMenuBarSlotChange(
 		element.tagName.toLowerCase().endsWith(VALID_MENU_ELEMEMENT_SUFFIX)
 	);
 	assignedElements.forEach((element) => {
-		(element as HTMLElement).style.display =
-			element === menuBar ? 'block' : 'none';
+		if (element === menuBar) {
+            (element as HTMLElement).style.removeProperty('display'); // Remove inline display style
+        } else {
+            (element as HTMLElement).style.display = 'none'; // Set display to 'none'
+        }
 	});
 	if (menuBar) {
 		menuBar.addEventListener(

--- a/libs/components/src/lib/rich-text-editor/rich-text-editor.ts
+++ b/libs/components/src/lib/rich-text-editor/rich-text-editor.ts
@@ -131,4 +131,13 @@ export class RichTextEditor extends VividElement {
 			console.warn(`Invalid text size: ${size}`);
 		}
 	}
+
+	setSelectionDecoration(decoration: string) {
+		try {
+			this.#editor?.setSelectionDecoration(decoration);
+		} catch (e: any) {
+			// eslint-disable-next-line no-console
+			console.warn(`Invalid decoration: ${decoration}`);
+		}
+	}
 }


### PR DESCRIPTION
Notice that the `monospace` icon is currently not present and will appear once it will be added to the icon repo.