### PR TITLE
chore(vue-wrappers): remove unnecessary aria-current declaration (VIV-000)

### DIFF
--- a/libs/components/metadata.json
+++ b/libs/components/metadata.json
@@ -8,12 +8,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "expandMode",
 					"description": "Controls the expand mode of the Accordion, either allowing\nsingle or multiple item expansion.",
 					"type": "'single' | 'multi'",
@@ -69,12 +63,6 @@
 			"registerFunctionName": "registerAccordionItem",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "expanded",
 					"description": "Expands or collapses the item.",
@@ -194,12 +182,6 @@
 					"propertyName": "appearance"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "shape",
 					"description": "The shape the ActionGroup should have.",
 					"type": "'rounded' | 'pill'",
@@ -257,12 +239,6 @@
 			"registerFunctionName": "registerAlert",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "connotation",
 					"description": "Sets an appropriate icon / icon color for the connotation.",
@@ -404,12 +380,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"description": "The connotation the audio-player should have.",
 					"type": "'accent' | 'cta'",
@@ -536,12 +506,6 @@
 					"propertyName": "appearance"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"description": "The connotation the avatar should have.",
 					"type": "'accent' | 'cta'",
@@ -631,12 +595,6 @@
 					"type": "'filled' | 'duotone' | 'subtle' | 'subtle-light'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "connotation",
@@ -730,12 +688,6 @@
 					"propertyName": "actionText"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"type": "'information' | 'announcement' | 'success' | 'warning' | 'alert'",
 					"attributeName": "connotation",
@@ -814,14 +766,7 @@
 			"vividModulePath": "libs/components/src/lib/breadcrumb/breadcrumb.ts",
 			"registerFunctionName": "registerBreadcrumb",
 			"description": "",
-			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				}
-			],
+			"props": [],
 			"events": [
 				{
 					"name": "blur",
@@ -865,12 +810,6 @@
 			"registerFunctionName": "registerBreadcrumbItem",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "ariaExpanded",
 					"description": "See https://www.w3.org/WAI/PF/aria/roles#link for more information",
@@ -997,12 +936,6 @@
 					"type": "'filled' | 'outlined' | 'ghost' | 'ghost-light' | 'outlined-light'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "autofocus",
@@ -1263,12 +1196,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "datetime",
 					"description": "The date within a week of choice.\nAccepts any parameter acceptable by the `Date()` constructor.",
 					"type": "Date | string",
@@ -1391,12 +1318,6 @@
 					"propertyName": "appearance"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"description": "The connotation the calendar event should have.",
 					"type": "'accent' | 'cta' | 'success' | 'alert' | 'warning' | 'information' | 'announcement'",
@@ -1488,12 +1409,6 @@
 					"type": "'elevated' | 'ghost' | 'outlined'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "elevation",
@@ -1595,12 +1510,6 @@
 			"registerFunctionName": "registerCheckbox",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "checked",
 					"description": "The current checkedness of the element. This property serves as a mechanism\nto set the `checked` property through both property assignment and the\n.setAttribute() method. This is useful for setting the field's checkedness\nin UI libraries that bind data through the .setAttribute() API\nand don't support IDL attribute binding.",
@@ -1764,12 +1673,6 @@
 					"type": "'fieldset' | 'ghost'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "autocomplete",
@@ -1979,12 +1882,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "generateHeader",
 					"description": "Whether the grid should automatically generate a header row and its type",
 					"type": "'none' | 'default' | 'sticky'",
@@ -2078,12 +1975,6 @@
 			"registerFunctionName": "registerDataGrid",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "ariaSelected",
 					"description": "Indicates the selected status.",
@@ -2202,12 +2093,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "ariaSelected",
 					"description": "Indicates the selected status.",
 					"type": "string",
@@ -2298,12 +2183,6 @@
 			"registerFunctionName": "registerDatePicker",
 			"description": "Single date picker component.",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "disabled",
 					"description": "Sets the element's disabled state. A disabled element will not be included during form submission.",
@@ -2430,12 +2309,6 @@
 			"registerFunctionName": "registerDateRangePicker",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "disabled",
 					"description": "Sets the element's disabled state. A disabled element will not be included during form submission.",
@@ -2606,12 +2479,6 @@
 			"registerFunctionName": "registerDateTimePicker",
 			"description": "Single date picker component.",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "clock",
 					"description": "Forces a 12h or 24h clock to be used.",
@@ -2788,12 +2655,6 @@
 			"description": "Base class for dial-pad",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "callActive",
 					"description": "Indicates the active state of the dial-pad.",
 					"type": "boolean",
@@ -2948,12 +2809,6 @@
 			"registerFunctionName": "registerDialog",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "dismissButtonAriaLabel",
 					"type": "string",
@@ -3125,12 +2980,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "orientation",
 					"description": "The orientation of the divider.",
 					"type": "'horizontal' | 'vertical'",
@@ -3188,12 +3037,6 @@
 			"registerFunctionName": "registerEmptyState",
 			"description": "An empty state element. Used when there is no data to display to the user.",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "connotation",
 					"description": "The connotation the empty state should have.",
@@ -3279,12 +3122,6 @@
 			"registerFunctionName": "registerFab",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "autofocus",
 					"description": "Determines if the element should receive document focus on page load.",
@@ -3465,12 +3302,6 @@
 					"type": "string",
 					"attributeName": "accept",
 					"propertyName": "accept"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "disabled",
@@ -3699,12 +3530,6 @@
 					"propertyName": "alternate"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "elevationShadow",
 					"description": "header elevation shadow",
 					"type": "boolean",
@@ -3765,12 +3590,6 @@
 			"registerFunctionName": "registerIcon",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "connotation",
 					"description": "The connotation the icon should have.",
@@ -3837,12 +3656,6 @@
 			"registerFunctionName": "registerLayout",
 			"description": "[--layout-grid-template-columns=repeat([the `auto-sizing` mapped value],\nminmax([the `column-basis` mapped value], 1fr))] - Controls the `grid-template-columns` of the layout.",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "autoSizing",
 					"description": "sets the initial preferred auto-sizing from predefined available options",
@@ -3928,12 +3741,6 @@
 					"type": "string | HTMLElement",
 					"attributeName": "anchor",
 					"propertyName": "anchor"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "autoDismiss",
@@ -4059,12 +3866,6 @@
 			"registerFunctionName": "registerMenuItem",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "checkAppearance",
 					"description": "Controls the appearance of the check indicator.",
@@ -4207,14 +4008,7 @@
 			"vividModulePath": "libs/components/src/lib/nav/nav.ts",
 			"registerFunctionName": "registerNav",
 			"description": "",
-			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				}
-			],
+			"props": [],
 			"events": [
 				{
 					"name": "blur",
@@ -4264,12 +4058,6 @@
 					"type": "'ghost' | 'ghost-light'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "connotation",
@@ -4359,12 +4147,6 @@
 					"type": "'ghost' | 'ghost-light'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "ariaExpanded",
@@ -4502,12 +4284,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"type": "'accent' | 'information' | 'success' | 'warning' | 'announcement' | 'alert'",
 					"attributeName": "connotation",
@@ -4581,12 +4357,6 @@
 					"type": "'fieldset' | 'ghost'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "autoComplete",
@@ -4852,12 +4622,6 @@
 			"description": "An Option Custom HTML Element.\nImplements https://www.w3.org/TR/wai-aria-1.1/#option | ARIA option .",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "disabled",
 					"description": "The disabled state of the option.",
 					"type": "boolean",
@@ -4963,12 +4727,6 @@
 			"registerFunctionName": "registerPagination",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "navIcons",
 					"type": "boolean",
@@ -5076,12 +4834,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"description": "Indicates the progress' connotation.",
 					"type": "'accent' | 'success' | 'alert' | 'cta' | 'pacific'",
@@ -5175,12 +4927,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"type": "'accent' | 'success' | 'alert' | 'cta'",
 					"attributeName": "connotation",
@@ -5264,12 +5010,6 @@
 			"registerFunctionName": "registerRadio",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "ariaLabel",
 					"type": "string",
@@ -5394,12 +5134,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "disabled",
 					"description": "Disables the radio group and child radios.",
 					"type": "boolean",
@@ -5497,12 +5231,6 @@
 			"registerFunctionName": "registerRangeSlider",
 			"description": "Base class for range-slider",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "ariaEndLabel",
 					"description": "Aria label for the end thumb",
@@ -5707,12 +5435,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "selectionEnd",
 					"type": "number",
 					"attributeName": "selection-end",
@@ -5785,12 +5507,6 @@
 					"type": "'fieldset' | 'ghost'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "clearable",
@@ -6029,12 +5745,6 @@
 					"propertyName": "appearance"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "disabled",
 					"description": "Sets the element's disabled state. A disabled element will not be included during form submission.",
 					"type": "boolean",
@@ -6243,12 +5953,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "checked",
 					"description": "Controls the checked state of the box",
 					"type": "boolean",
@@ -6347,12 +6051,6 @@
 					"propertyName": "alternate"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "modal",
 					"description": "sets the side drawer's type to modal",
 					"type": "boolean",
@@ -6441,12 +6139,6 @@
 			"registerFunctionName": "registerSlider",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "connotation",
 					"description": "slider connotation",
@@ -6628,12 +6320,6 @@
 					"propertyName": "appearance"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "connotation",
 					"description": "The connotation the split button should have.",
 					"type": "'accent' | 'announcement' | 'cta' | 'success' | 'alert'",
@@ -6746,12 +6432,6 @@
 			"registerFunctionName": "registerSwitch",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "checked",
 					"description": "The current checkedness of the element. This property serves as a mechanism\nto set the `checked` property through both property assignment and the\n.setAttribute() method. This is useful for setting the field's checkedness\nin UI libraries that bind data through the .setAttribute() API\nand don't support IDL attribute binding.",
@@ -6876,12 +6556,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "ariaSelected",
 					"type": "string",
 					"attributeName": "aria-selected",
@@ -6996,14 +6670,7 @@
 			"vividModulePath": "libs/components/src/lib/tab-panel/tab-panel.ts",
 			"registerFunctionName": "registerTabPanel",
 			"description": "",
-			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				}
-			],
+			"props": [],
 			"events": [
 				{
 					"name": "blur",
@@ -7060,12 +6727,6 @@
 					"type": "boolean",
 					"attributeName": "activeindicator",
 					"propertyName": "activeindicator"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "connotation",
@@ -7164,12 +6825,6 @@
 					"type": "'subtle' | 'duotone'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "connotation",
@@ -7289,14 +6944,7 @@
 			"vividModulePath": "libs/components/src/lib/tag-group/tag-group.ts",
 			"registerFunctionName": "registerTagGroup",
 			"description": "",
-			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				}
-			],
+			"props": [],
 			"events": [
 				{
 					"name": "blur",
@@ -7342,12 +6990,6 @@
 			"registerFunctionName": "registerTextArea",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "autofocus",
 					"description": "Indicates that this element should get focus after the page finishes loading.",
@@ -7574,12 +7216,6 @@
 					"type": "'fieldset' | 'ghost'",
 					"attributeName": "appearance",
 					"propertyName": "appearance"
-				},
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
 				},
 				{
 					"name": "autoComplete",
@@ -7829,12 +7465,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "clock",
 					"description": "Forces a 12h or 24h clock to be used.",
 					"type": "'12h' | '24h'",
@@ -7996,12 +7626,6 @@
 					"propertyName": "anchor"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "headline",
 					"description": "the optional title of the toggletip",
 					"type": "string",
@@ -8096,12 +7720,6 @@
 					"propertyName": "anchor"
 				},
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "open",
 					"type": "boolean",
 					"attributeName": "open",
@@ -8169,12 +7787,6 @@
 			"registerFunctionName": "registerTreeItem",
 			"description": "",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "disabled",
 					"description": "When true, the control will be immutable by user interaction. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled | disabled HTML attribute for more information.",
@@ -8271,12 +7883,6 @@
 			"description": "",
 			"props": [
 				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
-				{
 					"name": "renderCollapsedNodes",
 					"description": "/**\n When true, the control will be appear expanded by user interaction.",
 					"type": "boolean",
@@ -8329,12 +7935,6 @@
 			"registerFunctionName": "registerVideoPlayer",
 			"description": "Base class for video-player",
 			"props": [
-				{
-					"name": "ariaCurrent",
-					"description": "Indicates the element that represents the current item within a container or set of related elements.",
-					"type": "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-					"attributeName": "aria-current"
-				},
 				{
 					"name": "autoplay",
 					"description": "Allows the video will play automatically (muted)",

--- a/libs/wrapper-gen/src/metadata/customElementDeclarations.ts
+++ b/libs/wrapper-gen/src/metadata/customElementDeclarations.ts
@@ -70,16 +70,7 @@ const findDeclaration = (
 const BaseElementDeclaration: Declaration = {
 	name: 'HTMLElement',
 	kind: 'class',
-	attributes: [
-		{
-			name: 'aria-current',
-			description:
-				'Indicates the element that represents the current item within a container or set of related elements.',
-			type: {
-				text: "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'",
-			},
-		},
-	],
+	attributes: [],
 	events: [
 		{
 			name: 'click',


### PR DESCRIPTION
Like other aria attributes, aria-current doesn't need to be declared.