### PR TITLE
chore(docs): improve example names (VIV-000)

### DIFF
--- a/apps/docs/assets/scripts/live-sample.js
+++ b/apps/docs/assets/scripts/live-sample.js
@@ -34,8 +34,8 @@ function addButtonsHandlers() {
 	codePenButtons.forEach((btn) => btn.addEventListener('click', openCodePen));
 }
 
-function updateiFrameCode(idx) {
-	const { view, iframe } = samplesEditors.get(idx);
+function updateiFrameCode(id) {
+	const { view, iframe } = samplesEditors.get(id);
 
 	const placeholder = iframe.contentDocument.querySelector('#_target');
 	const updatedCode = view.state.doc.toString().trim();
@@ -54,15 +54,15 @@ function addSamplesEditors() {
 	codeBlocks.forEach((cbd) => {
 		const code = cbd.textContent.trim();
 		cbd.innerHTML = '';
-		const idx = +cbd.dataset.index;
+		const id = cbd.dataset.exampleId;
 
-		const iframe = document.querySelector(`#iframe-sample-${idx}`);
+		const iframe = document.querySelector(`#iframe-sample-${id}`);
 		const view = new EditorView({
 			doc: code,
 			extensions: [
-				keymap.of([{ key: 'Ctrl-Enter', run: () => updateiFrameCode(idx) }]),
+				keymap.of([{ key: 'Ctrl-Enter', run: () => updateiFrameCode(id) }]),
 				theme.of(EditorView.theme({})),
-				EditorView.updateListener.of(sampleChanged(idx)),
+				EditorView.updateListener.of(sampleChanged(id)),
 				minimalSetup,
 				bracketMatching(),
 				html(),
@@ -72,7 +72,7 @@ function addSamplesEditors() {
 			root: window.document,
 		});
 
-		samplesEditors.set(idx, {
+		samplesEditors.set(id, {
 			view,
 			iframe,
 		});
@@ -81,20 +81,20 @@ function addSamplesEditors() {
 	setEditorsTheme();
 }
 
-function sampleChanged(idx) {
+function sampleChanged(id) {
 	let debounceID;
 
 	return (v) => {
 		if (!v.docChanged) return;
 
 		clearTimeout(debounceID);
-		debounceID = setTimeout(() => updateiFrameCode(idx), 500);
+		debounceID = setTimeout(() => updateiFrameCode(id), 500);
 	};
 }
 
 function codeCopyButtonClick(event) {
 	const button = event.target;
-	const { view } = samplesEditors.get(+button.dataset.index);
+	const { view } = samplesEditors.get(button.dataset.exampleId);
 
 	navigator.clipboard
 		.writeText(view.state.doc.toString().trim())
@@ -116,7 +116,7 @@ let codePenForm = null;
 
 function openCodePen(event) {
 	const button = event.target;
-	const { view } = samplesEditors.get(+button.dataset.index);
+	const { view } = samplesEditors.get(button.dataset.exampleId);
 
 	const codePenPayload = JSON.stringify({
 		html: `<div class="vvd-root">\n${view.state.doc.toString().trim()}\n</div>`,
@@ -174,7 +174,7 @@ function addLocaleSwitcher() {
 
 function switchLocale(event) {
 	const select = event.target;
-	const { iframe } = samplesEditors.get(+select.dataset.index);
+	const { iframe } = samplesEditors.get(select.dataset.exampleId);
 
 	iframe.contentWindow.setLocale(locales[select.value]);
 	iframe.contentWindow.document.documentElement.lang = select.value;

--- a/apps/docs/assets/scripts/visual-tests/visual-tests-utils.ts
+++ b/apps/docs/assets/scripts/visual-tests/visual-tests-utils.ts
@@ -60,7 +60,7 @@ export function extractHTMLBlocksFromReadme(pathToReadme: string): string[] {
 }
 
 export async function loadPage({ page }: { page: Page }) {
-	await page.goto('http://127.0.0.1:8080/frames/cbd-code-block-0.html');
+	await page.goto('http://127.0.0.1:8080/playground/');
 }
 
 export async function loadTemplate({

--- a/apps/docs/content/playground.html
+++ b/apps/docs/content/playground.html
@@ -1,10 +1,16 @@
 <!-- Empty page with all Vivid components loaded. Used by the e2e tests. -->
 <!DOCTYPE html>
 <html class="vvd-root vvd-scrollbar" lang="en-US">
-<head>
-	<link rel="stylesheet" href="/docs/assets/styles/iframe.scss">
-	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
-	<script type="module" src="/docs/assets/scripts/code-example/main.ts"></script>
-</head>
-<body></body>
+	<head>
+		<link rel="stylesheet" href="/docs/assets/styles/iframe.scss" />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&family=Roboto+Mono:wght@400;500&display=swap"
+			rel="stylesheet"
+		/>
+		<script
+			type="module"
+			src="/docs/assets/scripts/code-example/main.ts"
+		></script>
+	</head>
+	<body></body>
 </html>

--- a/apps/docs/content/playground.html
+++ b/apps/docs/content/playground.html
@@ -1,0 +1,10 @@
+<!-- Empty page with all Vivid components loaded. Used by the e2e tests. -->
+<!DOCTYPE html>
+<html class="vvd-root vvd-scrollbar" lang="en-US">
+<head>
+	<link rel="stylesheet" href="/docs/assets/styles/iframe.scss">
+	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+	<script type="module" src="/docs/assets/scripts/code-example/main.ts"></script>
+</head>
+<body></body>
+</html>

--- a/apps/docs/libraries/markdown-it-fence.js
+++ b/apps/docs/libraries/markdown-it-fence.js
@@ -15,13 +15,21 @@ module.exports =
 
 		if (lang === 'html') {
 			if (additionalOptions.includes('preview')) {
-				return `${createCodeExample(token.content, additionalOptions)}\n`;
+				return `${createCodeExample({
+					code: token.content,
+					options: additionalOptions,
+					url: env.page.url,
+				})}\n`;
 			}
 
 			if (
 				additionalOptions.some((option) => option.includes('variables-preview'))
 			) {
-				return `${createVariablePreview(token.content, additionalOptions)}\n`;
+				return `${createVariablePreview({
+					code: token.content,
+					options: additionalOptions,
+					url: env.page.url,
+				})}\n`;
 			}
 		}
 

--- a/apps/docs/variables-preview/index.js
+++ b/apps/docs/variables-preview/index.js
@@ -44,7 +44,7 @@ const shadeOrder = Array.from(
 }, {});
 const getShadeOrder = (shade) => shadeOrder[shade] ?? 999;
 
-module.exports = function (exampleCode, options) {
+module.exports = function ({ code: exampleCode, options, url }) {
 	// Component name is given like this: variables-preview[component-name]
 	const componentName = options
 		.find((c) => c.includes('variables-preview'))
@@ -77,7 +77,12 @@ module.exports = function (exampleCode, options) {
 			output += `
 					<vwc-tab label='${connotation}'></vwc-tab>
 					<vwc-tab-panel>
-						${createCodeExample(exampleCodeWithStyle, options, connotationProperties)}
+						${createCodeExample({
+							code: exampleCodeWithStyle,
+							options,
+							cssProperties: connotationProperties,
+							url,
+						})}
 					</vwc-tab-panel>
 				`;
 		}
@@ -97,7 +102,12 @@ module.exports = function (exampleCode, options) {
 		});
 		const exampleCodeWithStyle =
 			renderVariablesStylesheet(cssProperties) + exampleCode;
-		return createCodeExample(exampleCodeWithStyle, options, cssProperties);
+		return createCodeExample({
+			code: exampleCodeWithStyle,
+			options,
+			cssProperties,
+			url,
+		});
 	}
 };
 


### PR DESCRIPTION
This changes the file names for code examples from something like `/frames/cbd-code-block-<random number>.html` to `/frames/components-accordion-1.html` to make them stable between eleventy runs