### PR TITLE
chore(repo): support merge queue (VIV-2587)

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -5,12 +5,13 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
     branches-ignore:
       ['dependabot/npm_and_yarn/**', 'release-please--branches--main--**']
+  # As the workflow is required, it needs to run on merge_groups as well. However, we will skip the actual check as it only works on pull requests.
   merge_group:
     types: [checks_requested]
 
 jobs:
   lint-pr-title:
-    if: ${{ github.event.pull_request.draft == false && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.draft == false && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -5,6 +5,8 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
     branches-ignore:
       ['dependabot/npm_and_yarn/**', 'release-please--branches--main--**']
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,6 +60,6 @@ jobs:
     secrets: inherit
 
   call-deploy-deno-preview:
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft == false && github.event_name != 'merge_group' }}
     needs: build
     uses: ./.github/workflows/_deploy-deno.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,8 @@ on:
       - converted_to_draft
     branches:
       - '**'
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ci-tests-${{ github.ref }}-1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
       release_sha: ${{ steps.should-release.outputs.release_sha }}
     steps:
       - id: should-release
-        run:
+        run: |
           echo "::set-output name=should_release::${{ needs.release-please.outputs.vivid_release_created == 'true' || needs.release-please.outputs.eslint_plugin_release_created == 'true' || github.event.inputs.force-release == 'true' }}"
           echo "::set-output name=release_sha::${{ needs.release-please.outputs.vivid_release_sha || needs.release-please.outputs.eslint_plugin_release_sha || github.event.pull_request.head.sha }}"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,10 +20,20 @@ jobs:
       eslint_plugin_release_created: ${{ steps.release.outputs['libs/eslint-plugin--release_created'] }}
       eslint_plugin_release_sha: ${{ steps.release.outputs['libs/eslint-plugin--sha'] }}
     steps:
+      # Checks if a release PR has been merged but not released yet (label: `autorelease: pending`)
+      # If so, creates releases (and tags) for the affected libraries in GitHub, updates the label, and sets the relevant outputs
+      # We have configured release-please to not create a release/tag for the vivid-vue library, as it is always released
+      # with vivid components which would make the release redundant.
+      # However, release-please depends on the vivid-vue tag to understand what has changed, so we create it ourselves in the
+      # next step.
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          # Defer creating a new release PR until after the vivid-vue tag is created
+          # Otherwise, release-please will create a new pull request for the vivid-vue changes immediately
+          skip-github-pull-request: true
 
-      # As we've instructed release-please not to create a vivid-vue release for now, we need to create the tag ourselves
+      # Whenever the components are released, also create a tag for the vivid-vue library
       - name: Create Vivid Vue Tag
         if: ${{ steps.release.outputs['libs/components--release_created'] }}
         uses: actions/github-script@v6
@@ -39,6 +49,15 @@ jobs:
                 ref: `refs/tags/vivid-vue-v${VIVID_VERSION}`,
                 sha: VIVID_SHA
             })
+
+      # Now we can create/update the release PR if needed
+      # This will look for commits since the last release and associate them with libraries if files in the library
+      # directories have changed. It will then create/update a release PR that updates the libraries changelog and versions
+      # based on the conventional commit messages.
+      - uses: googleapis/release-please-action@v4
+        id: pull-request
+        with:
+          skip-github-release: true
 
   should-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,60 +12,45 @@ on:
 
 name: release-please
 jobs:
-  tag-vivid-vue:
-    # As we've instructed release-please not to create a vivid-vue release for now, we need to create the tag ourselves
-    # This job will check if a tag for the current version of vivid-vue exists, and if not, create it
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Check tag
-        id: check_tag
-        run: |
-          TAG_NAME=vivid-vue-v$(node -p "require('./libs/vue-wrappers/package.json').version")
-          echo "Vivid-vue tag name: ${TAG_NAME}"
-
-          if git show-ref --tags --verify --quiet "refs/tags/${TAG_NAME}"; then
-            echo "Tag ${TAG_NAME} exists"
-          else
-            echo "Tag ${TAG_NAME} does not exist"
-            echo "::set-output name=missing_tag_name::${TAG_NAME}"
-          fi
-      - name: Create Tag
-        if: steps.check_tag.outputs.missing_tag_name
-        uses: actions/github-script@v6
-        env:
-          TAG_NAME: ${{ steps.check_tag.outputs.missing_tag_name }}
-        with:
-          script: |
-            const { TAG_NAME } = process.env
-            github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/tags/${TAG_NAME}`,
-                sha: context.sha
-            })
-
   release-please:
     runs-on: ubuntu-latest
-    needs: tag-vivid-vue
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      vivid_release_created: ${{ steps.release.outputs['libs/components--release_created'] }}
+      vivid_release_sha: ${{ steps.release.outputs['libs/components--sha'] }}
+      eslint_plugin_release_created: ${{ steps.release.outputs['libs/eslint-plugin--release_created'] }}
+      eslint_plugin_release_sha: ${{ steps.release.outputs['libs/eslint-plugin--sha'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+
+      # As we've instructed release-please not to create a vivid-vue release for now, we need to create the tag ourselves
+      - name: Create Vivid Vue Tag
+        if: ${{ steps.release.outputs['libs/components--release_created'] }}
+        uses: actions/github-script@v6
+        env:
+          VIVID_VERSION: ${{ steps.release.outputs['libs/components--version'] }}
+          VIVID_SHA: ${{ steps.release.outputs['libs/components--sha'] }}
+        with:
+          script: |
+            const { VIVID_VERSION, VIVID_SHA } = process.env
+            github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/vivid-vue-v${VIVID_VERSION}`,
+                sha: VIVID_SHA
+            })
 
   should-release:
     runs-on: ubuntu-latest
     needs: release-please
     outputs:
       should_release: ${{ steps.should-release.outputs.should_release }}
+      release_sha: ${{ steps.should-release.outputs.release_sha }}
     steps:
       - id: should-release
-        run: echo "::set-output name=should_release::${{ needs.release-please.outputs.releases_created == 'true' || github.event.inputs.force-release == 'true' }}"
+        run:
+          echo "::set-output name=should_release::${{ needs.release-please.outputs.vivid_release_created == 'true' || needs.release-please.outputs.eslint_plugin_release_created == 'true' || github.event.inputs.force-release == 'true' }}"
+          echo "::set-output name=release_sha::${{ needs.release-please.outputs.vivid_release_sha || needs.release-please.outputs.eslint_plugin_release_sha || github.event.pull_request.head.sha }}"
 
   build:
     runs-on: ubuntu-latest
@@ -74,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.should-release.outputs.release_sha }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Fixes `should_release` output not being set correctly due to incorrect YAML syntax causing the commands to run on one line (YAML should be illegal)
![image](https://github.com/user-attachments/assets/3655909b-d254-4b04-80de-629e50efe3e9)

Also fixes release-please creating a new release PR immediately due to the vivid-vue tag not being set at the time.